### PR TITLE
add github 'dev' ci pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+./target/*
+./src/test/*
+./logs
+./.git
+./.idea
+./.github

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,31 @@
+name: Dev docker image build and push
+
+on: 
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_ACCESS_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/projekt-inzynierski/survey-api:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM openjdk:17-jdk-alpine
+FROM maven:3.8.6-eclipse-temurin-17 as build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean install
+
+
+FROM openjdk:17-jdk-alpine as publish
 ARG JAR_FILE=target/*.jar
-COPY ./target/api-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/api-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
This pull request adds a github pipeline configuratoin, that builds and pushes a docker image after each merge to develop. The image is created with 'dev' tag.