### PR TITLE
121 offline responses

### DIFF
--- a/src/main/java/com/survey/api/configuration/SecurityConfig.java
+++ b/src/main/java/com/survey/api/configuration/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                     r.requestMatchers(HttpMethod.GET, "/api/surveys/short").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/respondentgroups").permitAll();
                     r.requestMatchers(HttpMethod.POST, "/api/surveyresponses").permitAll();
+                    r.requestMatchers(HttpMethod.POST, "/api/surveyresponses/offline").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/surveysendingpolicies").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/surveys/shortsummaries").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/summaries/histogram").permitAll();

--- a/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
+++ b/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
@@ -1,7 +1,8 @@
 package com.survey.api.controllers;
 
 import com.survey.application.dtos.SurveyResultDto;
-import com.survey.application.dtos.surveyDtos.SendSurveyResponseDto;
+import com.survey.application.dtos.surveyDtos.SendOfflineSurveyResponseDto;
+import com.survey.application.dtos.surveyDtos.SendOnlineSurveyResponseDto;
 import com.survey.application.dtos.surveyDtos.SurveyParticipationDto;
 import com.survey.application.services.SurveyResponsesService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -29,12 +30,21 @@ public class SurveyResponsesController {
     public SurveyResponsesController(SurveyResponsesService surveyResponsesService){
         this.surveyResponsesService = surveyResponsesService;
     }
+
     @CrossOrigin
     @PostMapping
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<SurveyParticipationDto> saveSurveyResponse(@Validated @RequestBody SendSurveyResponseDto sendSurveyResponseDto, @RequestHeader(value="Authorization", required = false) String token) throws InvalidAttributeValueException {
-        SurveyParticipationDto surveyParticipationDto = surveyResponsesService.saveSurveyResponse(sendSurveyResponseDto, token);
+    public ResponseEntity<SurveyParticipationDto> saveSurveyResponseOnline(@Validated @RequestBody SendOnlineSurveyResponseDto sendOnlineSurveyResponseDto, @RequestHeader(value="Authorization", required = false) String token) throws InvalidAttributeValueException {
+        SurveyParticipationDto surveyParticipationDto = surveyResponsesService.saveSurveyResponseOnline(sendOnlineSurveyResponseDto, token);
         return ResponseEntity.status(HttpStatus.CREATED).body(surveyParticipationDto);
+    }
+
+    @CrossOrigin
+    @PostMapping("/offline")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<List<SurveyParticipationDto>> saveSurveyResponseOffline(@RequestBody List<SendOfflineSurveyResponseDto> sendOfflineSurveyResponseDtoList){
+        List<SurveyParticipationDto> surveyParticipationDtoList = surveyResponsesService.saveSurveyResponsesOffline(sendOfflineSurveyResponseDtoList);
+        return ResponseEntity.status(HttpStatus.CREATED).body(surveyParticipationDtoList);
     }
 
     @GetMapping("/results")

--- a/src/main/java/com/survey/application/dtos/surveyDtos/SendOfflineSurveyResponseDto.java
+++ b/src/main/java/com/survey/application/dtos/surveyDtos/SendOfflineSurveyResponseDto.java
@@ -1,0 +1,22 @@
+package com.survey.application.dtos.surveyDtos;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class SendOfflineSurveyResponseDto implements SendSurveyResponseDto {
+    @NotNull
+    private UUID surveyId;
+    @NotNull
+    private OffsetDateTime startDate;
+    @NotNull
+    private OffsetDateTime finishDate;
+    @NotNull
+    private List<AnswerDto> answers;
+}

--- a/src/main/java/com/survey/application/dtos/surveyDtos/SendOnlineSurveyResponseDto.java
+++ b/src/main/java/com/survey/application/dtos/surveyDtos/SendOnlineSurveyResponseDto.java
@@ -1,0 +1,34 @@
+package com.survey.application.dtos.surveyDtos;
+
+import com.survey.api.validation.ValidSendSurveyResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ValidSendSurveyResponse
+@Accessors(chain = true)
+public class SendOnlineSurveyResponseDto implements SendSurveyResponseDto {
+    @NotNull
+    private UUID surveyId;
+
+    @NotNull
+    private OffsetDateTime startDate;
+
+    @NotNull
+    private OffsetDateTime finishDate;
+
+    @NotNull
+    private List<AnswerDto> answers;
+
+}

--- a/src/main/java/com/survey/application/dtos/surveyDtos/SendSurveyResponseDto.java
+++ b/src/main/java/com/survey/application/dtos/surveyDtos/SendSurveyResponseDto.java
@@ -1,25 +1,12 @@
 package com.survey.application.dtos.surveyDtos;
 
-import com.survey.api.validation.ValidSendSurveyResponse;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@ValidSendSurveyResponse
-@Accessors(chain = true)
-public class SendSurveyResponseDto {
-    @NotNull
-    private UUID surveyId;
-    @NotNull
-    private List<AnswerDto> answers;
+public interface SendSurveyResponseDto {
+    UUID getSurveyId();
+    OffsetDateTime getStartDate();
+    OffsetDateTime getFinishDate();
+    List<AnswerDto> getAnswers();
 }

--- a/src/main/java/com/survey/application/services/SurveyParticipationTimeValidationService.java
+++ b/src/main/java/com/survey/application/services/SurveyParticipationTimeValidationService.java
@@ -1,0 +1,9 @@
+package com.survey.application.services;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public interface SurveyParticipationTimeValidationService {
+    OffsetDateTime getCorrectSurveyParticipationDateTimeOnline(UUID identityUserId, UUID surveyId, OffsetDateTime surveyStartDate, OffsetDateTime surveyFinishDate);
+    OffsetDateTime getCorrectSurveyParticipationDateTimeOffline(UUID identityUserId, UUID surveyId, OffsetDateTime surveyStartDate, OffsetDateTime surveyFinishDate);
+}

--- a/src/main/java/com/survey/application/services/SurveyParticipationTimeValidationServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveyParticipationTimeValidationServiceImpl.java
@@ -1,0 +1,100 @@
+package com.survey.application.services;
+
+import com.survey.domain.models.SurveyParticipationTimeSlot;
+import com.survey.domain.models.SurveySendingPolicy;
+import com.survey.domain.repository.SurveyParticipationRepository;
+import com.survey.domain.repository.SurveySendingPolicyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class SurveyParticipationTimeValidationServiceImpl implements SurveyParticipationTimeValidationService{
+
+    private static final int ALLOWED_LATE_MINUTES = 5;
+
+    private final SurveySendingPolicyRepository surveySendingPolicyRepository;
+    private final SurveyParticipationRepository surveyParticipationRepository;
+
+    @Autowired
+    public SurveyParticipationTimeValidationServiceImpl(SurveySendingPolicyRepository surveySendingPolicyRepository, SurveyParticipationRepository surveyParticipationRepository) {
+        this.surveySendingPolicyRepository = surveySendingPolicyRepository;
+        this.surveyParticipationRepository = surveyParticipationRepository;
+    }
+
+
+    @Override
+    public OffsetDateTime getCorrectSurveyParticipationDateTimeOnline(UUID identityUserId, UUID surveyId, OffsetDateTime surveyStartDate, OffsetDateTime surveyFinishDate) {
+        SurveyParticipationTimeSlot currentTimeSlot = validateAndFindTimeSlot(surveyId, surveyStartDate, identityUserId);
+
+        if (!isWithinTimeSlot(currentTimeSlot, surveyStartDate, surveyFinishDate)) {
+            throw new IllegalArgumentException("Start and finish dates do not fit within the time slot.");
+        }
+
+        return calculateParticipationDate(currentTimeSlot, surveyStartDate, surveyFinishDate);
+    }
+
+    @Override
+    public OffsetDateTime getCorrectSurveyParticipationDateTimeOffline(UUID identityUserId, UUID surveyId, OffsetDateTime surveyStartDate, OffsetDateTime surveyFinishDate) {
+        SurveyParticipationTimeSlot timeSlot = findTimeSlotForStartDate(surveyId, surveyStartDate);
+
+        if (timeSlot == null ||
+            hasExistingParticipation(surveyId, identityUserId, timeSlot) ||
+                !isWithinTimeSlot(timeSlot, surveyStartDate, surveyFinishDate)){
+            return null;
+        }
+
+        return calculateParticipationDate(timeSlot, surveyStartDate, surveyFinishDate);
+    }
+
+
+
+    private SurveyParticipationTimeSlot validateAndFindTimeSlot(UUID surveyId, OffsetDateTime surveyStartDate, UUID identityUserId) {
+        SurveyParticipationTimeSlot timeSlot = findTimeSlotForStartDate(surveyId, surveyStartDate);
+
+        if (timeSlot == null) {
+            throw new IllegalArgumentException("No active time slot found for the given start date: " + surveyStartDate);
+        }
+
+        if (hasExistingParticipation(surveyId, identityUserId, timeSlot)) {
+            throw new IllegalArgumentException("Respondent already participated in this survey during the time slot: " +
+                    timeSlot.getStart() + " - " + timeSlot.getFinish());
+        }
+
+        return timeSlot;
+    }
+
+    private SurveyParticipationTimeSlot findTimeSlotForStartDate(UUID surveyId, OffsetDateTime surveyStartDate) {
+        if (surveyStartDate.isAfter(OffsetDateTime.now())) {
+            return null;
+        }
+
+        List<SurveySendingPolicy> policies = surveySendingPolicyRepository.findAllBySurveyId(surveyId);
+        return policies.stream()
+                .flatMap(policy -> policy.getTimeSlots().stream())
+                .filter(slot -> !slot.isDeleted() &&
+                        surveyStartDate.isAfter(slot.getStart()) &&
+                        surveyStartDate.isBefore(slot.getFinish()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean hasExistingParticipation(UUID surveyId, UUID respondentId, SurveyParticipationTimeSlot timeSlot) {
+        return surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(surveyId, respondentId, timeSlot.getStart(), timeSlot.getFinish());
+    }
+
+    private boolean isWithinTimeSlot(SurveyParticipationTimeSlot timeSlot, OffsetDateTime startDate, OffsetDateTime finishDate) {
+        return startDate.isBefore(finishDate) &&
+                startDate.isAfter(timeSlot.getStart()) &&
+                startDate.isBefore(timeSlot.getFinish()) &&
+                finishDate.isBefore(timeSlot.getFinish().plusMinutes(ALLOWED_LATE_MINUTES));
+    }
+
+    private OffsetDateTime calculateParticipationDate(SurveyParticipationTimeSlot timeSlot, OffsetDateTime startDate, OffsetDateTime finishDate) {
+        return finishDate.isBefore(timeSlot.getFinish()) ? finishDate : startDate;
+    }
+
+}

--- a/src/main/java/com/survey/application/services/SurveyResponsesService.java
+++ b/src/main/java/com/survey/application/services/SurveyResponsesService.java
@@ -1,7 +1,8 @@
 package com.survey.application.services;
 
 import com.survey.application.dtos.SurveyResultDto;
-import com.survey.application.dtos.surveyDtos.SendSurveyResponseDto;
+import com.survey.application.dtos.surveyDtos.SendOfflineSurveyResponseDto;
+import com.survey.application.dtos.surveyDtos.SendOnlineSurveyResponseDto;
 import com.survey.application.dtos.surveyDtos.SurveyParticipationDto;
 
 import javax.management.InvalidAttributeValueException;
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface SurveyResponsesService {
-    SurveyParticipationDto saveSurveyResponse(SendSurveyResponseDto sendSurveyResponseDto, String token) throws InvalidAttributeValueException;
+    SurveyParticipationDto saveSurveyResponseOnline(SendOnlineSurveyResponseDto sendOnlineSurveyResponseDto, String token) throws InvalidAttributeValueException;
+    List<SurveyParticipationDto> saveSurveyResponsesOffline(List<SendOfflineSurveyResponseDto> sendOfflineSurveyResponseDtoList);
     List<SurveyResultDto> getSurveyResults(UUID surveyId, OffsetDateTime dateFrom, OffsetDateTime dateTo);
 }

--- a/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
@@ -1,16 +1,12 @@
 package com.survey.application.services;
 
+import com.survey.api.validation.SendSurveyResponseDtoValidator;
 import com.survey.application.dtos.LocalizationPointDto;
 import com.survey.application.dtos.SurveyResultDto;
-import com.survey.application.dtos.surveyDtos.AnswerDto;
-import com.survey.application.dtos.surveyDtos.SendSurveyResponseDto;
-import com.survey.application.dtos.surveyDtos.SurveyParticipationDto;
+import com.survey.application.dtos.surveyDtos.*;
 import com.survey.domain.models.*;
 import com.survey.domain.models.enums.QuestionType;
-import com.survey.domain.repository.OptionRepository;
-import com.survey.domain.repository.QuestionRepository;
-import com.survey.domain.repository.SurveyParticipationRepository;
-import com.survey.domain.repository.SurveyRepository;
+import com.survey.domain.repository.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import org.modelmapper.ModelMapper;
@@ -21,7 +17,6 @@ import org.springframework.web.context.annotation.RequestScope;
 
 import javax.management.InvalidAttributeValueException;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,30 +25,38 @@ import java.util.stream.Stream;
 @RequestScope
 public class SurveyResponsesServiceImpl implements SurveyResponsesService {
     private final SurveyParticipationRepository surveyParticipationRepository;
+    private final SurveySendingPolicyRepository surveySendingPolicyRepository;
     private final SurveyRepository surveyRepository;
     private final OptionRepository optionRepository;
     private final QuestionRepository questionRepository;
     private final ClaimsPrincipalServiceImpl claimsPrincipalServiceImpl;
     private final ModelMapper modelMapper;
     private final EntityManager entityManager;
+    private final SendSurveyResponseDtoValidator sendSurveyResponseDtoValidator;
+    private final SurveyParticipationTimeValidationService surveyParticipationTimeValidationService;
+
 
 
     @Autowired
     public SurveyResponsesServiceImpl(
             SurveyParticipationRepository surveyParticipationRepository,
+            SurveySendingPolicyRepository surveySendingPolicyRepository,
             SurveyRepository surveyRepository,
             OptionRepository optionRepository,
             QuestionRepository questionRepository,
             ClaimsPrincipalServiceImpl claimsPrincipalServiceImpl,
             ModelMapper modelMapper,
-            EntityManager entityManager) {
+            EntityManager entityManager, SendSurveyResponseDtoValidator sendSurveyResponseDtoValidator, SurveyParticipationTimeValidationService surveyParticipationTimeValidationService) {
         this.surveyParticipationRepository = surveyParticipationRepository;
+        this.surveySendingPolicyRepository = surveySendingPolicyRepository;
         this.surveyRepository = surveyRepository;
         this.optionRepository = optionRepository;
         this.questionRepository = questionRepository;
         this.claimsPrincipalServiceImpl = claimsPrincipalServiceImpl;
         this.modelMapper = modelMapper;
         this.entityManager = entityManager;
+        this.sendSurveyResponseDtoValidator = sendSurveyResponseDtoValidator;
+        this.surveyParticipationTimeValidationService = surveyParticipationTimeValidationService;
     }
 
     private Survey findSurveyById(UUID surveyId) {
@@ -66,13 +69,20 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
     }
 
 
-    private SurveyParticipation saveSurveyParticipation(IdentityUser identityUser, Survey survey) {
-        SurveyParticipation surveyParticipation = new SurveyParticipation();
-        surveyParticipation.setIdentityUser(identityUser);
-        surveyParticipation.setDate(OffsetDateTime.now(ZoneOffset.UTC));
-        surveyParticipation.setSurvey(survey);
-        return surveyParticipation;
+    private SurveyParticipation saveSurveyParticipation(IdentityUser identityUser, Survey survey, OffsetDateTime startDate, OffsetDateTime finishDate, boolean isOnline) {
+        OffsetDateTime participationDate = isOnline
+                ? surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(identityUser.getId(), survey.getId(), startDate, finishDate)
+                : surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(identityUser.getId(), survey.getId(), startDate, finishDate);
+
+        if (participationDate == null && !isOnline) return null;
+
+        SurveyParticipation participation = new SurveyParticipation();
+        participation.setIdentityUser(identityUser);
+        participation.setDate(participationDate);
+        participation.setSurvey(survey);
+        return participation;
     }
+
     private Map<UUID, Option> findOptionsBySurveyId(List<UUID> questionIds) {
         return optionRepository.findByQuestionIdIn(questionIds)
                 .stream()
@@ -138,14 +148,40 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
 
     @Override
     @Transactional
-    public SurveyParticipationDto saveSurveyResponse(SendSurveyResponseDto sendSurveyResponseDto, String token) throws InvalidAttributeValueException {
+    public SurveyParticipationDto saveSurveyResponseOnline(SendOnlineSurveyResponseDto sendOnlineSurveyResponseDto, String token) throws InvalidAttributeValueException {
         IdentityUser identityUser = claimsPrincipalServiceImpl.findIdentityUser();
-        Survey survey = findSurveyById(sendSurveyResponseDto.getSurveyId());
-        SurveyParticipation surveyParticipation = saveSurveyParticipation(identityUser, survey);
-        SurveyParticipation finalSurveyParticipation = mapQuestionAnswers(sendSurveyResponseDto, surveyParticipation, survey);
+        Survey survey = findSurveyById(sendOnlineSurveyResponseDto.getSurveyId());
+        SurveyParticipation surveyParticipation = saveSurveyParticipation(identityUser, survey, sendOnlineSurveyResponseDto.getStartDate(), sendOnlineSurveyResponseDto.getFinishDate(), true);
+
+        if (surveyParticipation == null) {
+            throw new IllegalArgumentException("Failed to save survey participation. Participation data is invalid or missing.");
+        }
+
+        SurveyParticipation finalSurveyParticipation = mapQuestionAnswers(sendOnlineSurveyResponseDto, surveyParticipation, survey);
         surveyParticipationRepository.save(finalSurveyParticipation);
-        return mapToDto(finalSurveyParticipation, sendSurveyResponseDto, identityUser);
+        return mapToDto(finalSurveyParticipation, sendOnlineSurveyResponseDto, identityUser);
     }
+
+    @Override
+    @Transactional
+    public List<SurveyParticipationDto> saveSurveyResponsesOffline(List<SendOfflineSurveyResponseDto> sendOfflineSurveyResponseDtoList) {
+        IdentityUser identityUser = claimsPrincipalServiceImpl.findIdentityUser();
+
+        return sendOfflineSurveyResponseDtoList.stream()
+                .filter(dto -> sendSurveyResponseDtoValidator.isValid(dto, null))
+                .map(dto -> {
+                    Survey survey = findSurveyById(dto.getSurveyId());
+                    SurveyParticipation participation = saveSurveyParticipation(identityUser, survey, dto.getStartDate(), dto.getFinishDate(), false);
+                    if (participation == null) return null;
+
+                    SurveyParticipation finalParticipation = mapQuestionAnswers(dto, participation, survey);
+                    surveyParticipationRepository.save(finalParticipation);
+                    return mapToDto(finalParticipation, dto, identityUser);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/survey/application/services/SurveySendingPolicyServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveySendingPolicyServiceImpl.java
@@ -7,7 +7,6 @@ import com.survey.domain.repository.SurveyRepository;
 import com.survey.domain.repository.SurveySendingPolicyRepository;
 
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -83,6 +82,7 @@ public class SurveySendingPolicyServiceImpl implements SurveySendingPolicyServic
 
         return surveySendingPolicies.stream()
                 .map(policy -> convertToDto(policy, surveyId))
+                .filter(dto -> !dto.getTimeSlots().isEmpty())
                 .collect(Collectors.toList());
     }
 
@@ -104,6 +104,13 @@ public class SurveySendingPolicyServiceImpl implements SurveySendingPolicyServic
     private SurveySendingPolicyDto convertToDto(SurveySendingPolicy policy, UUID surveyId) {
         SurveySendingPolicyDto dto = modelMapper.map(policy, SurveySendingPolicyDto.class);
         dto.setSurveyId(surveyId);
+
+        List<SurveySendingPolicyTimesDto> nonDeletedTimeSlots = policy.getTimeSlots().stream()
+                .filter(slot -> !slot.isDeleted())
+                .map(slot -> modelMapper.map(slot, SurveySendingPolicyTimesDto.class))
+                .toList();
+
+        dto.setTimeSlots(nonDeletedTimeSlots);
         return dto;
     }
 }

--- a/src/main/java/com/survey/domain/repository/SurveyParticipationRepository.java
+++ b/src/main/java/com/survey/domain/repository/SurveyParticipationRepository.java
@@ -4,6 +4,7 @@ import com.survey.domain.models.SurveyParticipation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.UUID;
 import java.util.List;
@@ -15,4 +16,11 @@ public interface SurveyParticipationRepository extends JpaRepository<SurveyParti
 
     @Query("SELECT sp FROM SurveyParticipation sp WHERE sp.id = :surveyParticipationId AND sp.identityUser.id = :respondentId")
     Optional<SurveyParticipation> findByIdAndRespondentId(UUID surveyParticipationId, UUID respondentId);
+
+    @Query("SELECT COUNT(sp) > 0 FROM SurveyParticipation sp " +
+            "WHERE sp.survey.id = :surveyId " +
+            "AND sp.identityUser.id = :respondentId " +
+            "AND sp.date BETWEEN :startDate AND :endDate")
+    boolean existsBySurveyIdAndRespondentIdAndDateBetween(UUID surveyId, UUID respondentId, OffsetDateTime startDate, OffsetDateTime endDate);
+
 }

--- a/src/test/java/com/survey/api/integration/AuthenticationControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/AuthenticationControllerIntegrationTest.java
@@ -19,16 +19,16 @@ import java.util.UUID;
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-public class AuthenticationControllerTest{
+public class AuthenticationControllerIntegrationTest {
     private final WebTestClient webTestClient;
     private final ObjectMapper objectMapper;
     private final IdentityUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public AuthenticationControllerTest(WebTestClient webTestClient, ObjectMapper objectMapper,
-                                        IdentityUserRepository identityUserRepository,
-                                        PasswordEncoder passwordEncoder){
+    public AuthenticationControllerIntegrationTest(WebTestClient webTestClient, ObjectMapper objectMapper,
+                                                   IdentityUserRepository identityUserRepository,
+                                                   PasswordEncoder passwordEncoder){
 
         this.webTestClient = webTestClient;
         this.objectMapper = objectMapper;

--- a/src/test/java/com/survey/api/integration/LocalizationDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/LocalizationDataControllerIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-public class LocalizationDataIntegrationTest {
+public class LocalizationDataControllerIntegrationTest {
     private static final BigDecimal VALID_LATITUDE = new BigDecimal("52.237049");
     private static final BigDecimal VALID_LONGITUDE = new BigDecimal("21.017532");
     private static final BigDecimal INVALID_LATITUDE = new BigDecimal("60.237049");
@@ -46,7 +46,7 @@ public class LocalizationDataIntegrationTest {
     private final ResearchAreaRepository researchAreaRepository;
 
     @Autowired
-    public LocalizationDataIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider, LocalizationDataRepository localizationDataRepository, AuthenticationManager authenticationManager, ResearchAreaRepository researchAreaRepository) {
+    public LocalizationDataControllerIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider, LocalizationDataRepository localizationDataRepository, AuthenticationManager authenticationManager, ResearchAreaRepository researchAreaRepository) {
         this.webTestClient = webTestClient;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;

--- a/src/test/java/com/survey/api/integration/RespondentGroupsControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/RespondentGroupsControllerIntegrationTest.java
@@ -20,12 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-public class RespondentGroupsIntegrationTest {
+public class RespondentGroupsControllerIntegrationTest {
     private final WebTestClient webTestClient;
     private final RespondentGroupRepository repository;
 
     @Autowired
-    public RespondentGroupsIntegrationTest(WebTestClient webTestClient, RespondentGroupRepository repository) {
+    public RespondentGroupsControllerIntegrationTest(WebTestClient webTestClient, RespondentGroupRepository repository) {
         this.webTestClient = webTestClient;
         this.repository = repository;
     }

--- a/src/test/java/com/survey/api/integration/SensorDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/SensorDataControllerIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
-public class SensorDataIntegrationTest {
+public class SensorDataControllerIntegrationTest {
     private static final BigDecimal VALID_TEMPERATURE = new BigDecimal("21.5");
     private static final BigDecimal VALID_HUMIDITY = new BigDecimal("60.4");
 
@@ -43,7 +43,7 @@ public class SensorDataIntegrationTest {
     private final AuthenticationManager authenticationManager;
 
     @Autowired
-    public SensorDataIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider, SensorDataRepository sensorDataRepository, AuthenticationManager authenticationManager) {
+    public SensorDataControllerIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider, SensorDataRepository sensorDataRepository, AuthenticationManager authenticationManager) {
         this.webTestClient = webTestClient;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;

--- a/src/test/java/com/survey/application/services/InitialSurveyServiceTest.java
+++ b/src/test/java/com/survey/application/services/InitialSurveyServiceTest.java
@@ -70,9 +70,10 @@ class InitialSurveyServiceTest {
         assertEquals(QUESTION_ORDER, responseDtoList.get(0).getOrder());
         assertEquals(OPTION_ORDER, responseDtoList.get(0).getOptions().get(0).getOrder());
     }
+
     @Test
     void getInitialSurvey_ShouldThrowNoSuchElementException_WhenNoSurveyExists() {
-        when(initialSurveyRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+        when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.empty());
 
         NoSuchElementException exception = assertThrows(
                 NoSuchElementException.class,

--- a/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
+++ b/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
@@ -71,7 +71,7 @@ class RespondentDataServiceTest {
                 .thenReturn(Optional.of(identityUser));
         when(claimsPrincipalService.findIdentityUser()).thenReturn(identityUser);
         when(respondentDataRepository.existsByIdentityUserId(MOCK_USER_ID)).thenReturn(false);
-        when(initialSurveyRepository.findTopByOrderByIdAsc()).thenReturn(Optional.of(initialSurvey));
+        when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.of(initialSurvey));
         when(initialSurveyQuestionRepository.findAllById(List.of(respondentDataDto.getQuestionId())))
                 .thenReturn(List.of(mockQuestion));
         when(initialSurveyOptionRepository.findAllById(List.of(respondentDataDto.getOptionId())))
@@ -162,13 +162,13 @@ class RespondentDataServiceTest {
 
     @Test
     void getOrCreateInitialSurvey_ShouldReturnExistingSurvey_WhenExists() {
-        when(initialSurveyRepository.findTopByOrderByIdAsc()).thenReturn(Optional.of(initialSurvey));
+        when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.of(initialSurvey));
 
         InitialSurvey result = respondentDataService.getOrCreateInitialSurvey();
 
         assertNotNull(result);
         assertEquals(initialSurvey, result);
-        verify(initialSurveyRepository, times(1)).findTopByOrderByIdAsc();
+        verify(initialSurveyRepository, times(1)).findTopByRowVersionDesc();
         verify(initialSurveyRepository, never()).save(any(InitialSurvey.class));
     }
 
@@ -177,14 +177,14 @@ class RespondentDataServiceTest {
         InitialSurvey newSurvey = new InitialSurvey();
         newSurvey.setId(UUID.randomUUID());
 
-        when(initialSurveyRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+        when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.empty());
         when(initialSurveyRepository.save(any(InitialSurvey.class))).thenReturn(newSurvey);
 
         InitialSurvey result = respondentDataService.getOrCreateInitialSurvey();
 
         assertNotNull(result);
         assertSame(newSurvey, result);
-        verify(initialSurveyRepository, times(1)).findTopByOrderByIdAsc();
+        verify(initialSurveyRepository, times(1)).findTopByRowVersionDesc();
         verify(initialSurveyRepository, times(1)).save(any(InitialSurvey.class));
     }
 

--- a/src/test/java/com/survey/application/services/SurveyParticipationTimeValidationServiceTest.java
+++ b/src/test/java/com/survey/application/services/SurveyParticipationTimeValidationServiceTest.java
@@ -1,0 +1,427 @@
+package com.survey.application.services;
+
+import com.survey.domain.models.SurveyParticipationTimeSlot;
+import com.survey.domain.models.SurveySendingPolicy;
+import com.survey.domain.repository.SurveyParticipationRepository;
+import com.survey.domain.repository.SurveySendingPolicyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = SurveyParticipationTimeValidationService.class)
+public class SurveyParticipationTimeValidationServiceTest {
+
+    @InjectMocks
+    private SurveyParticipationTimeValidationServiceImpl surveyParticipationTimeValidationService;
+
+    @Mock
+    private SurveySendingPolicyRepository surveySendingPolicyRepository;
+
+    @Mock
+    private SurveyParticipationRepository surveyParticipationRepository;
+
+    private UUID surveyId;
+    private UUID identityUserId;
+    private OffsetDateTime nowUTC;
+
+
+    @BeforeEach
+    void setUp(){
+        surveyId = UUID.randomUUID();
+        identityUserId = UUID.randomUUID();
+        nowUTC = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    @Test
+    void online_ShouldReturnSurveyFinishDate() {
+        OffsetDateTime surveyStartDate = nowUTC.minusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC.minusMinutes(1);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(1));
+        timeSlot.setFinish(nowUTC.plusHours(1));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId)))
+                .thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(false);
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNotNull(result);
+        assertEquals(surveyFinishDate, result);
+
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+
+    @Test
+    void online_ShouldReturnSurveyStartDate_WhenSurveyFinishDateIsLateButFitsInLateBuffer() {
+        OffsetDateTime surveyStartDate = nowUTC.minusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC;
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(1));
+        timeSlot.setFinish(nowUTC.minusMinutes(4));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId)))
+                .thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(false);
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNotNull(result);
+        assertEquals(surveyStartDate, result);
+
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenSurveyDoesNotHaveAnyTimeSlots() {
+        OffsetDateTime surveyStartDate = nowUTC.minusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC;
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(surveyId)).thenReturn(List.of());
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(any(), any(), any(), any()))
+                .thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("This survey does not have any currently active time slots."));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenSurveyHasTimeSlotsButNoneIsCurrentlyActive() {
+        OffsetDateTime surveyStartDate = nowUTC.minusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC;
+
+
+        ArrayList<SurveyParticipationTimeSlot> timeSlots = new ArrayList<>();
+
+        SurveyParticipationTimeSlot timeSlot1 = new SurveyParticipationTimeSlot();
+        timeSlot1.setStart(surveyStartDate.minusHours(5));
+        timeSlot1.setFinish(surveyFinishDate.minusHours(4));
+        timeSlot1.setDeleted(false);
+        timeSlots.add(timeSlot1);
+
+        SurveyParticipationTimeSlot timeSlot2 = new SurveyParticipationTimeSlot();
+        timeSlot2.setStart(surveyStartDate.plusHours(4));
+        timeSlot2.setFinish(surveyFinishDate.plusHours(5));
+        timeSlot2.setDeleted(false);
+        timeSlots.add(timeSlot2);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(timeSlots);
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(any(), any(), any(), any()))
+                .thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("This survey does not have any currently active time slots."));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenSurveyHasActiveTimeSlotButResponseFitsInPastTimeSlot() {
+        OffsetDateTime surveyStartDate = nowUTC.minusHours(4).minusMinutes(30);
+        OffsetDateTime surveyFinishDate = nowUTC.minusHours(4).minusMinutes(25);
+
+
+        ArrayList<SurveyParticipationTimeSlot> timeSlots = new ArrayList<>();
+
+        SurveyParticipationTimeSlot timeSlotInThePast = new SurveyParticipationTimeSlot();
+        timeSlotInThePast.setStart(nowUTC.minusHours(5));
+        timeSlotInThePast.setFinish(nowUTC.minusHours(4));
+        timeSlotInThePast.setDeleted(false);
+        timeSlots.add(timeSlotInThePast);
+
+        SurveyParticipationTimeSlot timeSlotActive = new SurveyParticipationTimeSlot();
+        timeSlotActive.setStart(nowUTC.minusHours(1));
+        timeSlotActive.setFinish(nowUTC.plusHours(1));
+        timeSlotActive.setDeleted(false);
+        timeSlots.add(timeSlotActive);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(timeSlots);
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(any(), any(), any(), any()))
+                .thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("SurveyStartDate and/or surveyFinishDate do not fit in time slot."));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenSurveyHasActiveTimeSlotButResponseFitsInFutureTimeSlot() {
+        OffsetDateTime surveyStartDate = nowUTC.plusHours(4).plusMinutes(25);
+        OffsetDateTime surveyFinishDate = nowUTC.plusHours(4).plusMinutes(30);
+
+
+        ArrayList<SurveyParticipationTimeSlot> timeSlots = new ArrayList<>();
+
+        SurveyParticipationTimeSlot timeSlotInTheFuture = new SurveyParticipationTimeSlot();
+        timeSlotInTheFuture.setStart(nowUTC.plusHours(4));
+        timeSlotInTheFuture.setFinish(nowUTC.plusHours(5));
+        timeSlotInTheFuture.setDeleted(false);
+        timeSlots.add(timeSlotInTheFuture);
+
+        SurveyParticipationTimeSlot timeSlotActive = new SurveyParticipationTimeSlot();
+        timeSlotActive.setStart(nowUTC.minusHours(1));
+        timeSlotActive.setFinish(nowUTC.plusHours(1));
+        timeSlotActive.setDeleted(false);
+        timeSlots.add(timeSlotActive);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(timeSlots);
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(any(), any(), any(), any()))
+                .thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("SurveyStartDate and/or surveyFinishDate do not fit in time slot."));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenSurveyStartDateIsAfterSurveyFinishDate() {
+        OffsetDateTime surveyStartDate = nowUTC;
+        OffsetDateTime surveyFinishDate = nowUTC.minusMinutes(5);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(1));
+        timeSlot.setFinish(nowUTC.plusHours(1));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(any(), any(), any(), any()))
+                .thenReturn(false);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("SurveyStartDate and/or surveyFinishDate do not fit in time slot."));
+    }
+
+    @Test
+    void online_ShouldThrowException_WhenRespondentAlreadyParticipated() {
+        OffsetDateTime surveyStartDate = nowUTC.minusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC;
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(1));
+        timeSlot.setFinish(nowUTC.plusHours(1));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId)))
+                .thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(true);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () ->
+                surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOnline(
+                        identityUserId, surveyId, surveyStartDate, surveyFinishDate));
+
+        assertTrue(exception.getMessage().contains("Respondent already participated in this survey in this time slot."));
+
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+
+
+
+    @Test
+    void offline_ShouldReturnSurveyStartDate_WhenSurveyFinishDateIsLateNoMoreThanAllowed() {
+        OffsetDateTime surveyStartDate = OffsetDateTime.now(ZoneOffset.UTC).minusHours(1);
+        OffsetDateTime surveyFinishDate = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(55);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(surveyStartDate.minusHours(1));
+        timeSlot.setFinish(surveyFinishDate.minusMinutes(4));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId)))
+                .thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(false);
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNotNull(result);
+        assertEquals(surveyStartDate, result);
+
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+
+    @Test
+    void offline_ShouldReturnSurveyFinishDate_WhenValidPastTimeSlotAndValidDates() {
+        OffsetDateTime surveyStartDate = nowUTC.minusHours(3);
+        OffsetDateTime surveyFinishDate = nowUTC.minusHours(2).minusMinutes(55);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(4));
+        timeSlot.setFinish(nowUTC.minusHours(2));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId))).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(false);
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNotNull(result);
+        assertEquals(surveyFinishDate, result);
+
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+
+    @Test
+    void offline_ShouldReturnNull_WhenNoMatchingTimeSlot() {
+        OffsetDateTime surveyStartDate = nowUTC.minusHours(2);
+        OffsetDateTime surveyFinishDate = nowUTC.minusHours(1);
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId))).thenReturn(List.of());
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNull(result);
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verifyNoInteractions(surveyParticipationRepository);
+    }
+
+    @Test
+    void offline_ShouldReturnNull_WhenTimeSlotNotInPast() {
+        OffsetDateTime surveyStartDate = nowUTC.plusMinutes(5);
+        OffsetDateTime surveyFinishDate = nowUTC.plusMinutes(10);
+
+        SurveyParticipationTimeSlot futureTimeSlot = new SurveyParticipationTimeSlot();
+        futureTimeSlot.setStart(nowUTC.plusMinutes(1));
+        futureTimeSlot.setFinish(nowUTC.plusMinutes(20));
+        futureTimeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(futureTimeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId))).thenReturn(List.of(policy));
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNull(result);
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verifyNoInteractions(surveyParticipationRepository);
+    }
+
+    @Test
+    void offline_ShouldReturnNull_WhenDatesOutsideTimeSlot() {
+        OffsetDateTime surveyStartDate = nowUTC.minusHours(6);
+        OffsetDateTime surveyFinishDate = nowUTC.minusHours(5).minusMinutes(30);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(4));
+        timeSlot.setFinish(nowUTC.minusHours(2));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId))).thenReturn(List.of(policy));
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNull(result);
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verifyNoInteractions(surveyParticipationRepository);
+    }
+
+    @Test
+    void offline_ShouldReturnNull_WhenRespondentAlreadyParticipated() {
+        OffsetDateTime surveyStartDate = nowUTC.minusHours(3);
+        OffsetDateTime surveyFinishDate = nowUTC.minusHours(2).minusMinutes(55);
+
+        SurveyParticipationTimeSlot timeSlot = new SurveyParticipationTimeSlot();
+        timeSlot.setStart(nowUTC.minusHours(4));
+        timeSlot.setFinish(nowUTC.minusHours(2));
+        timeSlot.setDeleted(false);
+
+        SurveySendingPolicy policy = new SurveySendingPolicy();
+        policy.setTimeSlots(List.of(timeSlot));
+
+        when(surveySendingPolicyRepository.findAllBySurveyId(eq(surveyId))).thenReturn(List.of(policy));
+        when(surveyParticipationRepository.existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), any(), any()))
+                .thenReturn(true);
+
+        OffsetDateTime result = surveyParticipationTimeValidationService.getCorrectSurveyParticipationDateTimeOffline(
+                identityUserId, surveyId, surveyStartDate, surveyFinishDate);
+
+        assertNull(result);
+        verify(surveySendingPolicyRepository).findAllBySurveyId(eq(surveyId));
+        verify(surveyParticipationRepository).existsBySurveyIdAndRespondentIdAndDateBetween(
+                eq(surveyId), eq(identityUserId), eq(timeSlot.getStart()), eq(timeSlot.getFinish()));
+    }
+}

--- a/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
+++ b/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -35,6 +36,8 @@ class SurveyResponsesServiceImplTest {
     private static final String OPTION_2 = "Option 2";
     private static final boolean YES_NO_ANSWER = true;
     private static final int NUMERIC_ANSWER = 4;
+    private static final BigDecimal VALID_LATITUDE = new BigDecimal("52.237049");
+    private static final BigDecimal VALID_LONGITUDE = new BigDecimal("21.017532");
 
     @Mock
     private EntityManager entityManager;
@@ -44,6 +47,7 @@ class SurveyResponsesServiceImplTest {
     private Survey survey;
     private IdentityUser user;
     private List<QuestionAnswer> questionAnswerList;
+    private List<LocalizationData> localizationDataList;
     private SurveyParticipation surveyParticipation;
 
     @BeforeEach
@@ -51,6 +55,7 @@ class SurveyResponsesServiceImplTest {
         survey = createSurvey();
         user = createIdentityUser();
         questionAnswerList = createQuestionAnswerList();
+        localizationDataList = createLocalizationDataList();
         surveyParticipation = createSurveyParticipation();
     }
 
@@ -71,14 +76,20 @@ class SurveyResponsesServiceImplTest {
         assertEquals(SURVEY_NAME, results.get(0).getSurveyName());
         assertEquals(QUESTION_1, results.get(0).getQuestion());
         assertEquals(OPTION_1, results.get(0).getAnswers().get(0));
+        assertEquals(VALID_LATITUDE, results.get(0).getLocalizations().get(0).getLatitude());
+        assertEquals(VALID_LONGITUDE, results.get(0).getLocalizations().get(0).getLongitude());
 
         assertEquals(SURVEY_NAME, results.get(1).getSurveyName());
         assertEquals(QUESTION_2, results.get(1).getQuestion());
         assertEquals(YES_NO_ANSWER, results.get(1).getAnswers().get(0));
+        assertEquals(VALID_LATITUDE, results.get(1).getLocalizations().get(0).getLatitude());
+        assertEquals(VALID_LONGITUDE, results.get(1).getLocalizations().get(0).getLongitude());
 
         assertEquals(SURVEY_NAME, results.get(2).getSurveyName());
         assertEquals(QUESTION_3, results.get(2).getQuestion());
         assertEquals(NUMERIC_ANSWER, results.get(2).getAnswers().get(0));
+        assertEquals(VALID_LATITUDE, results.get(2).getLocalizations().get(0).getLatitude());
+        assertEquals(VALID_LONGITUDE, results.get(2).getLocalizations().get(0).getLongitude());
 
         verify(mockQuery).setParameter("surveyId", surveyId);
         verify(mockQuery).setParameter("dateFrom", dateFrom);
@@ -112,6 +123,7 @@ class SurveyResponsesServiceImplTest {
         participation.setDate(OffsetDateTime.now(ZoneOffset.UTC));
         participation.setIdentityUser(user);
         participation.setQuestionAnswers(questionAnswerList);
+        participation.setLocalizationDataList(localizationDataList);
         return participation;
     }
 
@@ -126,6 +138,14 @@ class SurveyResponsesServiceImplTest {
         IdentityUser user = new IdentityUser();
         user.setId(UUID.randomUUID());
         return user;
+    }
+
+    private List<LocalizationData> createLocalizationDataList(){
+        LocalizationData localizationData = new LocalizationData();
+        localizationData.setLatitude(VALID_LATITUDE);
+        localizationData.setLongitude(VALID_LONGITUDE);
+        localizationData.setDateTime(OffsetDateTime.now());
+        return List.of(localizationData);
     }
 
     private List<QuestionAnswer> createQuestionAnswerList() {


### PR DESCRIPTION
## In this pr:
- Fixed old tests and moved test files to appropriate directories (integration, service, etc.)
- Fixed GET /surveysendingpolicies. This endpoint is used by admin-panel to display sending policy in calendar for given survey. Now it does not return time slots that have "isDeleted": true. 
- BUG: When sending policy is created using admin panel, then deleted, admin panel needs to be refreshed to create new policy that overlaps the deleted one.
-  Refactored POST /surveyresponses. (for sending survey response online). Now it takes 2 additional parameters "startDate" and "finishDate". 
	- Both fit in the same participationTimeSlot -> finishDate is saved in surveyParticipation
	- finishDate is up to 5 minutes late -> startDate is saved in surveyParticipation
- Added POST /surveyresponses/offline. It takes a list of the same DTO as /surveyresponses, but it validates them "silently". It will Always return 201 status code with responseDto of the survey_participations that could be saved successfully. Responses with errors are skipped.
- Refactored survey response validation 