### PR TITLE
#123: add filters to respondents

### DIFF
--- a/src/main/java/com/survey/api/controllers/RespondentDataController.java
+++ b/src/main/java/com/survey/api/controllers/RespondentDataController.java
@@ -2,9 +2,11 @@ package com.survey.api.controllers;
 
 import com.survey.application.dtos.CreateRespondentDataDto;
 import com.survey.application.services.RespondentDataService;
+import com.survey.domain.models.enums.RespondentFilterOption;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InvalidAttributeValueException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -35,8 +38,13 @@ public class RespondentDataController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<Map<String, Object>>> getAll(){
-        List<Map<String, Object>> response = respondentDataService.getAll();
+    public ResponseEntity<List<Map<String, Object>>> getAll(
+            @RequestParam(value = "filterOption", required = false) RespondentFilterOption filterOption,
+            @RequestParam(value = "amount", required = false) Integer amount,
+            @RequestParam(value = "from", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime from,
+            @RequestParam(value = "to", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime to
+    ){
+        List<Map<String, Object>> response = respondentDataService.getAll(filterOption, amount, from, to);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/survey/api/runners/DatabaseMigrationRunner.java
+++ b/src/main/java/com/survey/api/runners/DatabaseMigrationRunner.java
@@ -19,6 +19,12 @@ public class DatabaseMigrationRunner implements ApplicationRunner {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    public DatabaseMigrationRunner(Flyway flyway, IdentityUserRepository identityUserRepository, PasswordEncoder passwordEncoder) {
+        this.flyway = flyway;
+        this.identityUserRepository = identityUserRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
     @Override
     public void run(ApplicationArguments args) throws Exception {
         flyway.migrate();
@@ -26,11 +32,15 @@ public class DatabaseMigrationRunner implements ApplicationRunner {
     }
 
     private void addAdmin() {
+        String adminPassword = System.getenv("ADMIN_USER_PASSWORD");
+        if (adminPassword == null) {
+            throw new IllegalStateException("Admin password not set in environment variable.");
+        }
         if (identityUserRepository.count() == 0) {
             IdentityUser identityUser = new IdentityUser();
             identityUser.setUsername("Admin");
             identityUser.setRole("Admin");
-            identityUser.setPasswordHash(passwordEncoder.encode("qwerty"));
+            identityUser.setPasswordHash(passwordEncoder.encode(adminPassword));
             identityUserRepository.save(identityUser);
         }
     }

--- a/src/main/java/com/survey/api/runners/DatabaseMigrationRunner.java
+++ b/src/main/java/com/survey/api/runners/DatabaseMigrationRunner.java
@@ -4,6 +4,7 @@ import com.survey.domain.models.IdentityUser;
 import com.survey.domain.repository.IdentityUserRepository;
 import org.flywaydb.core.Flyway;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,6 +20,9 @@ public class DatabaseMigrationRunner implements ApplicationRunner {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
+    @Value("${ADMIN_USER_PASSWORD}")
+    private String adminPassword;
+
     public DatabaseMigrationRunner(Flyway flyway, IdentityUserRepository identityUserRepository, PasswordEncoder passwordEncoder) {
         this.flyway = flyway;
         this.identityUserRepository = identityUserRepository;
@@ -32,11 +36,10 @@ public class DatabaseMigrationRunner implements ApplicationRunner {
     }
 
     private void addAdmin() {
-        String adminPassword = System.getenv("ADMIN_USER_PASSWORD");
-        if (adminPassword == null) {
-            throw new IllegalStateException("Admin password not set in environment variable.");
-        }
         if (identityUserRepository.count() == 0) {
+            if (adminPassword == null) {
+                throw new IllegalStateException("Admin password not set in environment variable.");
+            }
             IdentityUser identityUser = new IdentityUser();
             identityUser.setUsername("Admin");
             identityUser.setRole("Admin");

--- a/src/main/java/com/survey/application/services/RespondentDataService.java
+++ b/src/main/java/com/survey/application/services/RespondentDataService.java
@@ -1,17 +1,19 @@
 package com.survey.application.services;
 
 import com.survey.application.dtos.CreateRespondentDataDto;
+import com.survey.domain.models.enums.RespondentFilterOption;
 import org.apache.coyote.BadRequestException;
 import org.springframework.security.authentication.BadCredentialsException;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InvalidAttributeValueException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
 public interface RespondentDataService {
 
     Map<String, Object> createRespondent(List<CreateRespondentDataDto> dto, String tokenBearerPrefix) throws BadCredentialsException, InvalidAttributeValueException, InstanceAlreadyExistsException, BadRequestException;
-    List<Map<String, Object>> getAll();
+    List<Map<String, Object>> getAll(RespondentFilterOption filterOption, Integer amount, OffsetDateTime from, OffsetDateTime to);
     Map<String, Object> getFromUserContext();
 }

--- a/src/main/java/com/survey/application/services/RespondentDataServiceImpl.java
+++ b/src/main/java/com/survey/application/services/RespondentDataServiceImpl.java
@@ -2,14 +2,12 @@ package com.survey.application.services;
 
 import com.survey.application.dtos.CreateRespondentDataDto;
 import com.survey.domain.models.*;
+import com.survey.domain.models.enums.RespondentFilterOption;
+import com.survey.domain.models.enums.Visibility;
 import com.survey.domain.repository.*;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.*;
 import org.apache.coyote.BadRequestException;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
@@ -18,6 +16,7 @@ import org.springframework.web.context.annotation.RequestScope;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InvalidAttributeValueException;
+import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -28,7 +27,6 @@ public class RespondentDataServiceImpl implements RespondentDataService{
     private final RespondentDataRepository respondentDataRepository;
     private final ClaimsPrincipalService claimsPrincipalService;
     private final EntityManager entityManager;
-    private final IdentityUserRepository identityUserRepository;
     private final InitialSurveyRepository initialSurveyRepository;
     private final InitialSurveyQuestionRepository initialSurveyQuestionRepository;
     private final InitialSurveyOptionRepository initialSurveyOptionRepository;
@@ -39,11 +37,10 @@ public class RespondentDataServiceImpl implements RespondentDataService{
 
     @Autowired
     public RespondentDataServiceImpl(RespondentDataRepository respondentDataRepository,
-                                     ClaimsPrincipalService claimsPrincipalService, IdentityUserRepository identityUserRepository, EntityManager entityManager, InitialSurveyRepository initialSurveyRepository, InitialSurveyQuestionRepository initialSurveyQuestionRepository, InitialSurveyOptionRepository initialSurveyOptionRepository, RespondentGroupRepository respondentGroupRepository, RespondentToGroupRepository respondentToGroupRepository) {
+                                     ClaimsPrincipalService claimsPrincipalService, EntityManager entityManager, InitialSurveyRepository initialSurveyRepository, InitialSurveyQuestionRepository initialSurveyQuestionRepository, InitialSurveyOptionRepository initialSurveyOptionRepository, RespondentGroupRepository respondentGroupRepository, RespondentToGroupRepository respondentToGroupRepository) {
         this.respondentDataRepository = respondentDataRepository;
         this.claimsPrincipalService = claimsPrincipalService;
         this.entityManager = entityManager;
-        this.identityUserRepository = identityUserRepository;
         this.initialSurveyRepository = initialSurveyRepository;
         this.initialSurveyQuestionRepository = initialSurveyQuestionRepository;
         this.initialSurveyOptionRepository = initialSurveyOptionRepository;
@@ -68,16 +65,126 @@ public class RespondentDataServiceImpl implements RespondentDataService{
 
     @Override
     @Transactional
-    public List<Map<String, Object>> getAll(){
+    public List<Map<String, Object>> getAll(RespondentFilterOption filterOption, Integer amount, OffsetDateTime from, OffsetDateTime to){
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<RespondentData> cq = cb.createQuery(RespondentData.class);
-        Root<RespondentData> respondentData = cq.from(RespondentData.class);
-        cq.select(respondentData);
+        CriteriaQuery<IdentityUser> cq = cb.createQuery(IdentityUser.class);
+        Root<IdentityUser> identityUserRoot = cq.from(IdentityUser.class);
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(identityUserRoot.get("role"), "Respondent"));
+
+        if(filterOption != null){
+            if (from == null || to == null || amount == null) {
+                throw new IllegalArgumentException("'from', 'to' and 'amount' are required for filtering.");
+            }
+            switch (filterOption) {
+                case skipped_surveys:
+                    Subquery<UUID> activeSurveySubquery = cq.subquery(UUID.class);
+                    Root<SurveyParticipationTimeSlot> timeSlotRoot = activeSurveySubquery.from(SurveyParticipationTimeSlot.class);
+                    activeSurveySubquery.select(timeSlotRoot.get("surveySendingPolicy").get("survey").get("id"))
+                            .where(
+                                    cb.and(
+                                            cb.equal(timeSlotRoot.get("isDeleted"), false),
+                                            cb.lessThanOrEqualTo(timeSlotRoot.get("finish"), to),
+                                            cb.greaterThanOrEqualTo(timeSlotRoot.get("start"), from)
+                                    )
+                            );
+
+                    Subquery<UUID> visibleSurveySubquery = cq.subquery(UUID.class);
+                    Root<SurveySection> surveySectionRoot = visibleSurveySubquery.from(SurveySection.class);
+
+                    Predicate alwaysVisible = cb.equal(surveySectionRoot.get("visibility"), Visibility.always);
+
+                    Join<SurveySection, SectionToUserGroup> sectionToGroupJoin = surveySectionRoot.join("sectionToUserGroups", JoinType.LEFT);
+                    Join<SectionToUserGroup, RespondentGroup> groupJoin = sectionToGroupJoin.join("group", JoinType.LEFT);
+                    Join<RespondentGroup, RespondentData> respondentDataJoin = groupJoin.join("respondentData", JoinType.LEFT);
+
+                    Predicate groupSpecificVisible = cb.and(
+                            cb.equal(surveySectionRoot.get("visibility"), Visibility.group_specific),
+                            respondentDataJoin.get("identityUserId").in(identityUserRoot.get("id"))
+                    );
+
+                    Predicate sectionVisible = cb.or(alwaysVisible, groupSpecificVisible);
+
+                    visibleSurveySubquery.select(surveySectionRoot.get("survey").get("id"))
+                            .where(sectionVisible);
+
+                    Subquery<UUID> activeVisibleSurveysSubquery = cq.subquery(UUID.class);
+                    Root<SurveySection> activeVisibleRoot = activeVisibleSurveysSubquery.from(SurveySection.class);
+                    activeVisibleSurveysSubquery.select(activeVisibleRoot.get("survey").get("id"))
+                            .where(
+                                    cb.and(
+                                            activeVisibleRoot.get("survey").get("id").in(activeSurveySubquery),
+                                            activeVisibleRoot.get("survey").get("id").in(visibleSurveySubquery)
+                                    )
+                            );
+
+                    Subquery<Long> activeVisibleSurveysCountSubquery = cq.subquery(Long.class);
+                    Root<SurveySection> countRoot = activeVisibleSurveysCountSubquery.from(SurveySection.class);
+                    activeVisibleSurveysCountSubquery.select(cb.countDistinct(countRoot.get("survey").get("id")))
+                            .where(countRoot.get("survey").get("id").in(activeVisibleSurveysSubquery));
+
+                    Subquery<Long> participationCountSubquery = cq.subquery(Long.class);
+                    Root<SurveyParticipation> participationRoot = participationCountSubquery.from(SurveyParticipation.class);
+                    participationCountSubquery.select(cb.count(participationRoot.get("id")))
+                            .where(
+                                    cb.and(
+                                            cb.equal(participationRoot.get("identityUser").get("id"),
+                                                    identityUserRoot.get("id")),
+                                            participationRoot.get("survey").get("id").in(
+                                                    activeVisibleSurveysSubquery
+                                            )
+                                    )
+                            );
+
+                    predicates.add(cb.ge(
+                            cb.diff(
+                                    activeVisibleSurveysCountSubquery,
+                                    participationCountSubquery.getSelection()
+                            ),
+                            amount.longValue()
+                    ));
+                    break;
+                case location_not_sent:
+                    OffsetDateTime adjustedFrom = from.plusDays(1);
+                    OffsetDateTime adjustedTo = to.plusDays(1);
+
+                    Subquery<Long> localizationCountSubquery = cq.subquery(Long.class);
+                    Root<LocalizationData> localizationRoot = localizationCountSubquery.from(LocalizationData.class);
+
+                    localizationCountSubquery.select(cb.count(localizationRoot.get("id")))
+                            .where(
+                                    cb.and(
+                                            cb.equal(localizationRoot.get("identityUser").get("id"), identityUserRoot.get("id")),
+                                            cb.between(localizationRoot.get("dateTime"), adjustedFrom, adjustedTo)
+                                    )
+                            );
+
+                    predicates.add(cb.lessThanOrEqualTo(localizationCountSubquery.getSelection(), amount.longValue()));
+                    break;
+                case sensors_data_not_sent:
+                    Subquery<Long> sensorDataCountSubquery = cq.subquery(Long.class);
+                    Root<SensorData> sensorDataRoot = sensorDataCountSubquery.from(SensorData.class);
+
+                    sensorDataCountSubquery.select(cb.count(sensorDataRoot.get("id")))
+                            .where(
+                                    cb.equal(sensorDataRoot.get("respondent").get("id"), identityUserRoot.get("id")),
+                                    cb.between(sensorDataRoot.get("dateTime"), from, to)
+                            );
+
+                    predicates.add(cb.lessThanOrEqualTo(sensorDataCountSubquery.getSelection(), amount.longValue()));
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid filter option: " + filterOption);
+
+            }
+        }
+
+        cq.select(identityUserRoot).where(cb.and(predicates.toArray(new Predicate[0])));
 
         return entityManager.createQuery(cq)
                 .getResultList()
                 .stream()
-                .map(this::mapRespondentDataToResponse)
+                .map(this::mapResultToResponse)
                 .collect(Collectors.toList());
     }
 
@@ -140,7 +247,6 @@ public class RespondentDataServiceImpl implements RespondentDataService{
         respondentToGroupRepository.saveAllAndFlush(respondentToGroupList);
     }
 
-
     private RespondentData initializeRespondentData(UUID userId) {
         RespondentData respondentData = new RespondentData();
         respondentData.setIdentityUserId(userId);
@@ -155,15 +261,6 @@ public class RespondentDataServiceImpl implements RespondentDataService{
                     InitialSurvey newSurvey = new InitialSurvey();
                     return initialSurveyRepository.save(newSurvey);
                 });
-    }
-
-    private UUID getCurrentUserUUID() {
-        String usernameFromJwt = getUsernameFromJwt();
-        return getUserUUID(usernameFromJwt);
-    }
-
-    private String getUsernameFromJwt() {
-        return claimsPrincipalService.getCurrentUsernameIfExists();
     }
 
     private void checkIfRespondentDataExists(UUID userId) throws InstanceAlreadyExistsException {
@@ -221,25 +318,36 @@ public class RespondentDataServiceImpl implements RespondentDataService{
         return respondentDataRepository.existsByIdentityUserId(userId);
     }
 
-    private UUID getUserUUID(String username) {
-        return identityUserRepository.findByUsername(username)
-                .map(IdentityUser::getId)
-                .orElse(null);
-    }
-
     private Map<String, Object> mapRespondentDataToResponse(RespondentData respondentData) {
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("id", respondentData.getIdentityUser().getId());
         response.put("username", respondentData.getUsername());
 
-        respondentData.getRespondentDataQuestions().forEach(respondentDataQuestion -> {
-            String questionContent = respondentDataQuestion.getQuestion().getContent();
-            respondentDataQuestion.getOptions().forEach(respondentDataOption -> {
-                UUID optionId = respondentDataOption.getOption().getId();
-                response.put(questionContent, optionId);
+        mapQuestionsAndOptions(respondentData, response);
+   
+        return response;
+    }
+    private Map<String, Object> mapResultToResponse(IdentityUser identityUser) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        UUID identityUserId = identityUser.getId();
+
+        response.put("id", identityUserId);
+        response.put("username", identityUser.getUsername());
+
+        RespondentData respondentData = respondentDataRepository.findByIdentityUserId(identityUserId);
+
+        if (respondentData != null) {
+            mapQuestionsAndOptions(respondentData, response);
+        }
+        return response;
+    }
+    private void mapQuestionsAndOptions(RespondentData respondentData, Map<String, Object> response) {
+        respondentData.getRespondentDataQuestions().forEach(question -> {
+            String questionContent = question.getQuestion().getContent();
+            question.getOptions().forEach(option -> {
+                String optionContent = option.getOption().getContent();
+                response.put(questionContent, optionContent);
             });
         });
-
-        return response;
     }
 }

--- a/src/main/java/com/survey/application/services/RespondentDataServiceImpl.java
+++ b/src/main/java/com/survey/application/services/RespondentDataServiceImpl.java
@@ -334,8 +334,8 @@ public class RespondentDataServiceImpl implements RespondentDataService{
         respondentData.getRespondentDataQuestions().forEach(question -> {
             String questionContent = question.getQuestion().getContent();
             question.getOptions().forEach(option -> {
-                String optionContent = option.getOption().getContent();
-                response.put(questionContent, optionContent);
+                UUID optionId = option.getOption().getId();
+                response.put(questionContent, optionId);
             });
         });
     }

--- a/src/main/java/com/survey/application/services/RespondentGroupServiceImpl.java
+++ b/src/main/java/com/survey/application/services/RespondentGroupServiceImpl.java
@@ -31,7 +31,7 @@ public class RespondentGroupServiceImpl implements RespondentGroupService {
             if(respondentDataRepository.existsByIdentityUserId(respondentId)){
                 throw new IllegalArgumentException("Invalid respondent ID - respondent doesn't exist");
             }
-            return respondentToGroupRepository.findGroupsByRespondentDataId(respondentId)
+            return respondentToGroupRepository.findGroupsByIdentityUserId(respondentId)
                     .stream()
                     .map(group -> modelMapper.map(group.getRespondentGroup(), RespondentGroupDto.class))
                     .collect(Collectors.toList());

--- a/src/main/java/com/survey/domain/models/enums/RespondentFilterOption.java
+++ b/src/main/java/com/survey/domain/models/enums/RespondentFilterOption.java
@@ -1,0 +1,7 @@
+package com.survey.domain.models.enums;
+
+public enum RespondentFilterOption {
+    skipped_surveys,
+    location_not_sent,
+    sensors_data_not_sent;
+}

--- a/src/main/java/com/survey/domain/models/enums/Visibility.java
+++ b/src/main/java/com/survey/domain/models/enums/Visibility.java
@@ -1,7 +1,10 @@
 package com.survey.domain.models.enums;
 
+import lombok.Getter;
+
 import java.util.Arrays;
 
+@Getter
 public enum Visibility {
     always(0),
     group_specific(1),
@@ -11,10 +14,6 @@ public enum Visibility {
 
     Visibility(int value) {
         this.value = value;
-    }
-
-    public int getValue() {
-        return value;
     }
 
     public static Visibility fromValue(int value) {

--- a/src/main/java/com/survey/domain/repository/RespondentToGroupRepository.java
+++ b/src/main/java/com/survey/domain/repository/RespondentToGroupRepository.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.UUID;
 
 public interface RespondentToGroupRepository extends JpaRepository<RespondentToGroup, UUID> {
-    @Query("SELECT rtg FROM RespondentToGroup rtg JOIN FETCH rtg.respondentGroup WHERE rtg.respondentData.id = :respondentId")
-    List<RespondentToGroup> findGroupsByRespondentDataId(UUID respondentId);
+    @Query("SELECT rtg FROM RespondentToGroup rtg JOIN FETCH rtg.respondentGroup WHERE rtg.respondentData.identityUserId = :identityUserId")
+    List<RespondentToGroup> findGroupsByIdentityUserId(UUID identityUserId);
+
 
 }

--- a/src/test/java/com/survey/api/integration/AuthenticationControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/AuthenticationControllerIntegrationTest.java
@@ -12,18 +12,22 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.UUID;
 
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 @AutoConfigureWebTestClient
 public class AuthenticationControllerIntegrationTest {
     private final WebTestClient webTestClient;
     private final ObjectMapper objectMapper;
     private final IdentityUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private static final String adminPassword = "testAdminPassword";
+
 
     @Autowired
     public AuthenticationControllerIntegrationTest(WebTestClient webTestClient, ObjectMapper objectMapper,
@@ -57,7 +61,7 @@ public class AuthenticationControllerIntegrationTest {
     @Test
     public void testLoginForExistingUserButWrongPassword() throws JsonProcessingException{
         String randomUsername = UUID.randomUUID().toString();
-        IdentityUser user = new IdentityUser(null, randomUsername, "some password hash", "ADMIN");
+        IdentityUser user = new IdentityUser(null, randomUsername, adminPassword, "ADMIN");
         userRepository.save(user);
 
         LoginDto dto = LoginDto
@@ -79,14 +83,14 @@ public class AuthenticationControllerIntegrationTest {
     @Test
     public void testLoginWIthCorrectCredentials() throws JsonProcessingException{
         String randomUsername = UUID.randomUUID().toString();
-        String passwordHash = passwordEncoder.encode("password");
+        String passwordHash = passwordEncoder.encode(adminPassword);
         IdentityUser user = new IdentityUser(null, randomUsername, passwordHash, "ADMIN");
         userRepository.save(user);
 
         LoginDto dto = LoginDto
                 .builder()
                 .withUsername(randomUsername)
-                .withPassword("password")
+                .withPassword(adminPassword)
                 .build();
 
         String json = objectMapper.writeValueAsString(dto);

--- a/src/test/java/com/survey/api/integration/LocalizationDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/LocalizationDataControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.math.BigDecimal;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 @AutoConfigureWebTestClient
 public class LocalizationDataControllerIntegrationTest {
     private static final BigDecimal VALID_LATITUDE = new BigDecimal("52.237049");

--- a/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
@@ -1,27 +1,40 @@
 package com.survey.api.integration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.survey.api.security.TokenProvider;
-import com.survey.application.dtos.CreateRespondentDataDto;
+import com.survey.application.dtos.*;
+import com.survey.application.dtos.initialSurvey.InitialSurveyQuestionResponseDto;
+import com.survey.application.dtos.surveyDtos.*;
 import com.survey.domain.models.*;
-import com.survey.domain.models.enums.InitialSurveyState;
+import com.survey.domain.models.enums.QuestionType;
+import com.survey.domain.models.enums.RespondentFilterOption;
+import com.survey.domain.models.enums.Visibility;
 import com.survey.domain.repository.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
 
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -31,76 +44,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RespondentDataControllerIntegrationTest {
     private final WebTestClient webTestClient;
     private final IdentityUserRepository userRepository;
+    private final RespondentToGroupRepository respondentToGroupRepository;
+    private final InitialSurveyRepository initialSurveyRepository;
+    private final SurveyRepository surveyRepository;
+    private final RespondentGroupRepository respondentGroupRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
     private final RespondentDataRepository respondentDataRepository;
-    private final InitialSurveyRepository initialSurveyRepository;
-    private final InitialSurveyQuestionRepository initialSurveyQuestionRepository;
-    private final InitialSurveyOptionRepository initialSurveyOptionRepository;
     private final AuthenticationManager authenticationManager;
     private static final String QUESTION_CONTENT = "What is your favorite color?";
     private static final int QUESTION_ORDER = 1;
-    private static final String OPTION_CONTENT = "Red";
+    private static final String OPTION_CONTENT_1 = "Red";
+    private static final String OPTION_CONTENT_2 = "Blue";
     private static final int OPTION_ORDER = 1;
-
+    private static final String SECTION_NAME = "Section1";
 
     @Autowired
-    public RespondentDataControllerIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, PasswordEncoder passwordEncoder,
-                                                   TokenProvider tokenProvider, RespondentDataRepository respondentDataRepository,
-                                                   InitialSurveyRepository initialSurveyRepository, InitialSurveyQuestionRepository initialSurveyQuestionRepository1, InitialSurveyOptionRepository initialSurveyOptionRepository1, AuthenticationManager authenticationManager) {
+    public RespondentDataControllerIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, RespondentToGroupRepository respondentToGroupRepository, InitialSurveyRepository initialSurveyRepository, SurveyRepository surveyRepository, RespondentGroupRepository respondentGroupRepository, PasswordEncoder passwordEncoder,
+                                                   TokenProvider tokenProvider, RespondentDataRepository respondentDataRepository, AuthenticationManager authenticationManager) {
         this.webTestClient = webTestClient;
         this.userRepository = userRepository;
+        this.respondentToGroupRepository = respondentToGroupRepository;
+        this.initialSurveyRepository = initialSurveyRepository;
+        this.surveyRepository = surveyRepository;
+        this.respondentGroupRepository = respondentGroupRepository;
         this.passwordEncoder = passwordEncoder;
         this.tokenProvider = tokenProvider;
         this.respondentDataRepository = respondentDataRepository;
-        this.initialSurveyRepository = initialSurveyRepository;
-        this.initialSurveyQuestionRepository = initialSurveyQuestionRepository1;
-        this.initialSurveyOptionRepository = initialSurveyOptionRepository1;
         this.authenticationManager = authenticationManager;
     }
-
+    @BeforeEach
+    void setUp() {
+        respondentToGroupRepository.deleteAll();
+        respondentDataRepository.deleteAll();
+        userRepository.deleteAll();
+        surveyRepository.deleteAll();
+        initialSurveyRepository.deleteAll();
+        List<RespondentGroup> groupsToDelete = respondentGroupRepository.findAll().stream()
+                .filter(group -> !group.getName().equals("All"))
+                .toList();
+        respondentGroupRepository.deleteAll(groupsToDelete);
+    }
     @Test
     void createRespondent_ShouldReturnCreatedResponse() {
-        IdentityUser identityUser = new IdentityUser()
-                .setRole("Respondent")
-                .setUsername("username")
-                .setPasswordHash(passwordEncoder.encode("password"));
+        IdentityUser validRespondent = createIdentityUserForRespondent("respondent");
+        String validRespondentToken = generateTokenForRespondent(validRespondent);
 
-        identityUser = userRepository.saveAndFlush(identityUser);
+        List<InitialSurveyQuestionResponseDto> initialSurvey = saveInitialSurvey();
+        CreateRespondentDataDto createRespondentDataDto = createRespondentDataDto(initialSurvey, 0);
 
-        InitialSurveyOption option = new InitialSurveyOption();
-        option.setOrder(OPTION_ORDER);
-        option.setContent(OPTION_CONTENT);
-
-        InitialSurveyQuestion question = new InitialSurveyQuestion();
-        question.setOrder(QUESTION_ORDER);
-        question.setContent(QUESTION_CONTENT);
-        question.setOptions(List.of(option));
-
-        InitialSurvey initialSurvey = new InitialSurvey();
-        initialSurvey.setQuestions(List.of(question));
-        initialSurvey.setState(InitialSurveyState.published);
-
-        initialSurvey.setState(InitialSurveyState.published);
-
-        initialSurveyRepository.saveAndFlush(initialSurvey);
-
-        CreateRespondentDataDto createDto = new CreateRespondentDataDto();
-        createDto.setQuestionId(initialSurvey.getQuestions().get(0).getId());
-        UUID optionId = initialSurvey.getQuestions().get(0).getOptions().get(0).getId();
-        createDto.setOptionId(optionId);
-
-        List<CreateRespondentDataDto> createDtoList = List.of(createDto);
-
-        Authentication authentication = authenticationManager
-                .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(),
-                        "password"));
-
-        String token = tokenProvider.generateToken(authentication);
-
-        Map<String, Object> bodyRespondent = webTestClient.post().uri("/api/respondents")
-                .header("Authorization", "Bearer " + token)
-                .bodyValue(createDtoList)
+        Map<String, Object> bodyRespondent = webTestClient.post()
+                .uri("/api/respondents")
+                .header("Authorization", "Bearer " + validRespondentToken)
+                .bodyValue(Collections.singletonList(createRespondentDataDto))
                 .exchange()
                 .expectStatus()
                 .isCreated()
@@ -108,29 +104,16 @@ public class RespondentDataControllerIntegrationTest {
                 .returnResult()
                 .getResponseBody();
 
-        RespondentData respondentData = respondentDataRepository.findByIdentityUserId(identityUser.getId());
-
         assertThat(bodyRespondent).isNotNull();
-        assertThat(bodyRespondent).containsEntry("id", respondentData.getId().toString());
-        assertThat(bodyRespondent).containsEntry("username", identityUser.getUsername());
-        assertThat(bodyRespondent).containsEntry(QUESTION_CONTENT, optionId.toString());
+        assertThat(bodyRespondent).containsEntry("id", validRespondent.getId().toString());
+        assertThat(bodyRespondent).containsEntry("username", validRespondent.getUsername());
+        assertThat(bodyRespondent).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_1);
     }
 
     @Test
     void getFromUserContext_ShouldGiveNotFound_WhenTheRespondentDataWasNotCreatedYet(){
-        IdentityUser identityUser = new IdentityUser()
-                .setId(UUID.randomUUID())
-                .setRole("Respondent")
-                .setUsername(UUID.randomUUID().toString())
-                .setPasswordHash(passwordEncoder.encode("password"));
-
-        identityUser = userRepository.saveAndFlush(identityUser);
-
-        Authentication authentication = authenticationManager
-                .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(),
-                        "password"));
-
-        String token = tokenProvider.generateToken(authentication);
+        IdentityUser respondent = createIdentityUserForRespondent("respondent");
+        String token = generateTokenForRespondent(respondent);
 
         webTestClient.get().uri("/api/respondents")
                 .header("Authorization", "Bearer " + token)
@@ -141,6 +124,358 @@ public class RespondentDataControllerIntegrationTest {
 
     @Test
     void getAllForAdminShouldBeOk(){
+        String adminToken = generateTokenForAdmin();
+
+        webTestClient.get().uri("/api/respondents/all")
+                .header("Authorization", "Bearer " + adminToken)
+                .exchange()
+                .expectStatus()
+                .isOk();
+    }
+
+    @Test
+    void getFromUserContext_ShouldReturnUserRespondentData_WhenDataExists() {
+        IdentityUser respondent = createIdentityUserForRespondent("respondent");
+        String token = generateTokenForRespondent(respondent);
+
+        List<InitialSurveyQuestionResponseDto> initialSurvey = saveInitialSurvey();
+        saveInitialSurveyResponse(initialSurvey, 0, token);
+
+        Map<String, Object> response = webTestClient.get().uri("/api/respondents")
+                .header("Authorization", "Bearer " + token)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .returnResult().getResponseBody();
+
+        assertThat(response).isNotNull();
+        assertThat(response).containsEntry("id", respondent.getId().toString());
+        assertThat(response).containsEntry("username", respondent.getUsername());
+        assertThat(response).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_1);
+    }
+
+    @Test
+    void getAll_WithFilterOptionSkippedSurvey_ShouldReturnOk() throws JsonProcessingException {
+        String adminToken = generateTokenForAdmin();
+        IdentityUser validRespondent = createIdentityUserForRespondent("respondent1");
+        String validRespondentToken = generateTokenForRespondent(validRespondent);
+        IdentityUser invalidRespondent = createIdentityUserForRespondent("respondent2");
+
+        ResponseSurveyDto survey = saveSurvey(createSurveyDto());
+        saveSurveySendingPolicy(survey.getId());
+        saveSurveyResponse(survey, validRespondentToken);
+
+        OffsetDateTime from = OffsetDateTime.now(UTC).minusYears(1);
+        OffsetDateTime to = OffsetDateTime.now(UTC).plusYears(1);
+
+        List<Map<String, Object>> response = webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/api/respondents/all")
+                        .queryParam("filterOption", RespondentFilterOption.skipped_surveys)
+                        .queryParam("from", from.toString())
+                        .queryParam("to", to.toString())
+                        .queryParam("amount", 1)
+                        .build())
+                .header("Authorization", "Bearer " + adminToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .returnResult().getResponseBody();
+
+        assertThat(response).isNotEmpty();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0)).containsEntry("id", invalidRespondent.getId().toString());
+        assertThat(response.get(0)).containsEntry("username", invalidRespondent.getUsername());
+    }
+
+    @Test
+    void getAll_WithFilterOptionSkippedSurvey_ForGroupSpecificSurveySection_ShouldReturnOk() throws JsonProcessingException {
+        String adminToken = generateTokenForAdmin();
+        IdentityUser validRespondent = createIdentityUserForRespondent("respondent1");
+        String validRespondentToken = generateTokenForRespondent(validRespondent);
+        IdentityUser invalidRespondent = createIdentityUserForRespondent("respondent2");
+        String invalidRespondentToken = generateTokenForRespondent(invalidRespondent);
+
+        List<InitialSurveyQuestionResponseDto> initialSurvey = saveInitialSurvey();
+        saveInitialSurveyResponse(initialSurvey, 0, validRespondentToken);
+        saveInitialSurveyResponse(initialSurvey, 1, invalidRespondentToken);
+
+        String groupId = respondentGroupRepository.findByGroupName(QUESTION_CONTENT + " - " + OPTION_CONTENT_2).getId().toString();
+        ResponseSurveyDto survey = saveSurvey(createSurveyGroupSpecificDto(groupId));
+        saveSurveySendingPolicy(survey.getId());
+
+        OffsetDateTime from = OffsetDateTime.now(UTC).minusYears(1);
+        OffsetDateTime to = OffsetDateTime.now(UTC).plusYears(1);
+
+        List<Map<String, Object>> response = webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/api/respondents/all")
+                        .queryParam("filterOption", RespondentFilterOption.skipped_surveys)
+                        .queryParam("from", from.toString())
+                        .queryParam("to", to.toString())
+                        .queryParam("amount", 1)
+                        .build())
+                .header("Authorization", "Bearer " + adminToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .returnResult().getResponseBody();
+
+        assertThat(response).isNotEmpty();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0)).containsEntry("id", invalidRespondent.getId().toString());
+        assertThat(response.get(0)).containsEntry("username", invalidRespondent.getUsername());
+        assertThat(response.get(0)).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_2);
+    }
+
+    @Test
+    void getAll_WithFilterOptionLocationNotSent_ShouldReturnOk() {
+        String adminToken = generateTokenForAdmin();
+        IdentityUser validRespondent = createIdentityUserForRespondent("respondent1");
+        String validRespondentToken = generateTokenForRespondent(validRespondent);
+        IdentityUser invalidRespondent = createIdentityUserForRespondent("respondent2");
+
+        saveLocalizationDataForRespondent(validRespondentToken, OffsetDateTime.now());
+        saveLocalizationDataForRespondent(validRespondentToken, OffsetDateTime.now().minusDays(1));
+
+        OffsetDateTime from = OffsetDateTime.now(UTC).minusYears(1);
+        OffsetDateTime to = OffsetDateTime.now(UTC).plusYears(1);
+
+        List<Map<String, Object>> response = webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/api/respondents/all")
+                        .queryParam("filterOption", RespondentFilterOption.location_not_sent)
+                        .queryParam("from", from.toString())
+                        .queryParam("to", to.toString())
+                        .queryParam("amount", 1)
+                        .build())
+                .header("Authorization", "Bearer " + adminToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .returnResult().getResponseBody();
+
+        assertThat(response).isNotEmpty();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0)).containsEntry("id", invalidRespondent.getId().toString());
+        assertThat(response.get(0)).containsEntry("username", invalidRespondent.getUsername());
+    }
+
+    @Test
+    void getAll_WithFilterOptionSensorDataNotSent_ShouldReturnOk() {
+        String adminToken = generateTokenForAdmin();
+        IdentityUser validRespondent = createIdentityUserForRespondent("respondent1");
+        String validRespondentToken = generateTokenForRespondent(validRespondent);
+        IdentityUser invalidRespondent = createIdentityUserForRespondent("respondent2");
+
+        saveSensorDataForRespondent(validRespondentToken, OffsetDateTime.now());
+        saveSensorDataForRespondent(validRespondentToken, OffsetDateTime.now().minusDays(2));
+
+        OffsetDateTime from = OffsetDateTime.now(UTC).minusYears(1);
+        OffsetDateTime to = OffsetDateTime.now(UTC).plusYears(1);
+
+        List<Map<String, Object>> response = webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/api/respondents/all")
+                        .queryParam("filterOption", RespondentFilterOption.sensors_data_not_sent)
+                        .queryParam("from", from.toString())
+                        .queryParam("to", to.toString())
+                        .queryParam("amount", 1)
+                        .build())
+                .header("Authorization", "Bearer " + adminToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .returnResult().getResponseBody();
+
+        assertThat(response).isNotEmpty();
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0)).containsEntry("id", invalidRespondent.getId().toString());
+        assertThat(response.get(0)).containsEntry("username", invalidRespondent.getUsername());
+    }
+
+    private void saveSensorDataForRespondent(String token, OffsetDateTime time) {
+        SensorDataDto entryDto = new SensorDataDto();
+        entryDto.setDateTime(time);
+        entryDto.setTemperature(new BigDecimal("21.5"));
+        entryDto.setHumidity(new BigDecimal("51.5"));
+
+        webTestClient.post()
+                .uri("/api/sensordata")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(List.of(entryDto))
+                .exchange()
+                .expectStatus().isCreated();
+    }
+    private void saveLocalizationDataForRespondent(String token, OffsetDateTime time){
+        LocalizationDataDto localizationDataDto = new LocalizationDataDto();
+        localizationDataDto.setLatitude(new BigDecimal("52.237049"));
+        localizationDataDto.setLongitude(new BigDecimal("22.237049"));
+        localizationDataDto.setDateTime(time);
+
+        webTestClient.post()
+                .uri("/api/localization")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(List.of(localizationDataDto))
+                .exchange()
+                .expectStatus().isCreated();
+    }
+
+    private List<InitialSurveyQuestionResponseDto> saveInitialSurvey() {
+        InitialSurveyOption option1 = new InitialSurveyOption();
+        option1.setContent(OPTION_CONTENT_1);
+        option1.setOrder(1);
+
+        InitialSurveyOption option2 = new InitialSurveyOption();
+        option2.setContent(OPTION_CONTENT_2);
+        option2.setOrder(2);
+
+        InitialSurveyQuestion question = new InitialSurveyQuestion();
+        question.setContent(QUESTION_CONTENT);
+        question.setOrder(QUESTION_ORDER);
+        question.setOptions(List.of(option1, option2));
+
+        List<InitialSurveyQuestionResponseDto> initialSurvey =  webTestClient.post()
+                .uri("/api/initialsurvey")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Collections.singletonList(question))
+                .exchange()
+                .expectStatus().isCreated()
+                .expectBodyList(InitialSurveyQuestionResponseDto.class)
+                .returnResult()
+                .getResponseBody();
+
+        webTestClient.patch()
+                .uri("/api/initialsurvey/publish")
+                .exchange()
+                .expectStatus().isNoContent();
+
+        return initialSurvey;
+    }
+    private CreateRespondentDataDto createRespondentDataDto(List<InitialSurveyQuestionResponseDto> initialSurvey, Integer optionId){
+        CreateRespondentDataDto createRespondentDataDto = new CreateRespondentDataDto();
+        createRespondentDataDto.setQuestionId(initialSurvey.get(0).getId());
+        createRespondentDataDto.setOptionId(initialSurvey.get(0).getOptions().get(optionId).getId());
+        return createRespondentDataDto;
+    }
+    private void saveInitialSurveyResponse(List<InitialSurveyQuestionResponseDto> initialSurvey, Integer optionId, String token){
+        webTestClient.post()
+                .uri("/api/respondents")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Collections.singletonList(createRespondentDataDto(initialSurvey, optionId)))
+                .exchange()
+                .expectStatus().isCreated();
+    }
+    private ResponseSurveyDto saveSurvey(CreateSurveyDto createSurveyDto) throws JsonProcessingException {
+        String jsonSurveyDto = new ObjectMapper().writeValueAsString(createSurveyDto);
+
+        MultipartBodyBuilder multipartBodyBuilder = new MultipartBodyBuilder();
+        multipartBodyBuilder.part("json", jsonSurveyDto);
+
+        return webTestClient.post()
+                .uri("/api/surveys")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(multipartBodyBuilder.build()))
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectBody(ResponseSurveyDto.class)
+                .returnResult()
+                .getResponseBody();
+    }
+    private void saveSurveySendingPolicy(UUID surveyId) {
+        SurveyParticipationTimeStartFinishDto participationTimeSlot = new SurveyParticipationTimeStartFinishDto();
+        participationTimeSlot.setStart(OffsetDateTime.now(UTC).minusMonths(1));
+        participationTimeSlot.setFinish(OffsetDateTime.now(UTC).plusMonths(1));
+
+        CreateSurveySendingPolicyDto createSurveySendingPolicyDto = new CreateSurveySendingPolicyDto();
+        createSurveySendingPolicyDto.setSurveyId(surveyId);
+        createSurveySendingPolicyDto.setSurveyParticipationTimeSlots(List.of(participationTimeSlot));
+
+        webTestClient.post()
+                .uri("/api/surveysendingpolicies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createSurveySendingPolicyDto)
+                .exchange()
+                .expectStatus()
+                .isCreated();
+    }
+
+    private void saveSurveyResponse(ResponseSurveyDto surveyDto, String token){
+        SelectedOptionDto selectedOptionDto = new SelectedOptionDto();
+        selectedOptionDto.setOptionId(surveyDto.getSections().get(0).getQuestions().get(0).getOptions().get(0).getId());
+
+        AnswerDto answerDto = new AnswerDto();
+        answerDto.setQuestionId(surveyDto.getSections().get(0).getQuestions().get(0).getId());
+        answerDto.setSelectedOptions(List.of(selectedOptionDto));
+
+        SendOnlineSurveyResponseDto sendSurveyResponseDto = new SendOnlineSurveyResponseDto();
+        sendSurveyResponseDto.setSurveyId(surveyDto.getId());
+        sendSurveyResponseDto.setAnswers(List.of(answerDto));
+        sendSurveyResponseDto.setStartDate(OffsetDateTime.now().minusHours(1));
+        sendSurveyResponseDto.setFinishDate(OffsetDateTime.now());
+
+        webTestClient.post()
+                .uri("/api/surveyresponses")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(sendSurveyResponseDto)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectBody(SurveyParticipationDto.class)
+                .returnResult()
+                .getResponseBody();
+    }
+    private CreateSurveyDto createSurveyDto(){
+        CreateOptionDto createOptionDto = new CreateOptionDto();
+        createOptionDto.setLabel(OPTION_CONTENT_1);
+        createOptionDto.setOrder(OPTION_ORDER);
+        createOptionDto.setImagePath(null);
+
+        CreateQuestionDto createQuestionDto = new CreateQuestionDto();
+        createQuestionDto.setQuestionType(QuestionType.single_choice.name());
+        createQuestionDto.setOrder(QUESTION_ORDER);
+        createQuestionDto.setContent(QUESTION_CONTENT);
+        createQuestionDto.setOptions(List.of(createOptionDto));
+
+        CreateSurveySectionDto createSurveySectionDto = new CreateSurveySectionDto();
+        createSurveySectionDto.setName(SECTION_NAME);
+        createSurveySectionDto.setOrder(1);
+        createSurveySectionDto.setDisplayOnOneScreen(true);
+        createSurveySectionDto.setVisibility(Visibility.always.name());
+        createSurveySectionDto.setQuestions(List.of(createQuestionDto));
+
+        CreateSurveyDto createSurveyDto = new CreateSurveyDto();
+        createSurveyDto.setName("Survey");
+        createSurveyDto.setSections(List.of(createSurveySectionDto));
+        return createSurveyDto;
+    }
+    private CreateSurveyDto createSurveyGroupSpecificDto(String groupId){
+        CreateOptionDto createOptionDto = new CreateOptionDto();
+        createOptionDto.setLabel(OPTION_CONTENT_1);
+        createOptionDto.setOrder(OPTION_ORDER);
+        createOptionDto.setImagePath(null);
+
+        CreateQuestionDto createQuestionDto = new CreateQuestionDto();
+        createQuestionDto.setQuestionType(QuestionType.single_choice.name());
+        createQuestionDto.setOrder(QUESTION_ORDER);
+        createQuestionDto.setContent(QUESTION_CONTENT);
+        createQuestionDto.setOptions(List.of(createOptionDto));
+
+        CreateSurveySectionDto createSurveySectionDto = new CreateSurveySectionDto();
+        createSurveySectionDto.setName(SECTION_NAME);
+        createSurveySectionDto.setOrder(1);
+        createSurveySectionDto.setDisplayOnOneScreen(true);
+        createSurveySectionDto.setVisibility(Visibility.group_specific.name());
+        createSurveySectionDto.setGroupId(groupId);
+        createSurveySectionDto.setQuestions(List.of(createQuestionDto));
+
+        CreateSurveyDto createSurveyDto = new CreateSurveyDto();
+        createSurveyDto.setName("Survey Group Specific");
+        createSurveyDto.setSections(List.of(createSurveySectionDto));
+        return createSurveyDto;
+    }
+    private String generateTokenForAdmin() {
         IdentityUser identityUser = new IdentityUser()
                 .setId(UUID.randomUUID())
                 .setRole("ADMIN")
@@ -153,81 +488,22 @@ public class RespondentDataControllerIntegrationTest {
                 .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(),
                         "password"));
 
-        String token = tokenProvider.generateToken(authentication);
-
-        webTestClient.get().uri("/api/respondents/all")
-                .header("Authorization", "Bearer " + token)
-                .exchange()
-                .expectStatus()
-                .isOk();
+        return tokenProvider.generateToken(authentication);
     }
-    @Test
-    void getFromUserContext_ShouldReturnUserRespondentData_WhenDataExists() {
+    private IdentityUser createIdentityUserForRespondent(String username){
         IdentityUser identityUser = new IdentityUser()
                 .setRole("Respondent")
-                .setUsername("testUser")
-                .setPasswordHash(passwordEncoder.encode("testPassword"));
+                .setUsername(username)
+                .setPasswordHash(passwordEncoder.encode("password"));
 
         identityUser = userRepository.saveAndFlush(identityUser);
-
-        InitialSurveyOption option = new InitialSurveyOption();
-        option.setContent(OPTION_CONTENT);
-        option.setOrder(OPTION_ORDER);
-        option.setRowVersion(new byte[]{0});
-        option = initialSurveyOptionRepository.saveAndFlush(option);
-
-        InitialSurveyQuestion question = new InitialSurveyQuestion();
-        question.setContent(QUESTION_CONTENT);
-        question.setOrder(QUESTION_ORDER);
-        question.setRowVersion(new byte[]{0});
-
-        question.setOptions(Collections.singletonList(option));
-        question = initialSurveyQuestionRepository.saveAndFlush(question);
-        option.setQuestion(question);
-
-        InitialSurvey initialSurvey = new InitialSurvey();
-        initialSurvey.setState(InitialSurveyState.published);
-        initialSurvey.setQuestions(Collections.singletonList(question));
-        initialSurvey.setRowVersion(new byte[]{0});
-
-        initialSurvey.setState(InitialSurveyState.published);
-        initialSurvey = initialSurveyRepository.saveAndFlush(initialSurvey);
-
-        question.setInitialSurvey(initialSurvey);
-        question = initialSurveyQuestionRepository.saveAndFlush(question);
-
-        RespondentData respondentData = new RespondentData();
-        respondentData.setIdentityUserId(identityUser.getId());
-        respondentData.setIdentityUser(identityUser);
-        respondentData.setInitialSurvey(initialSurvey);
-
-        RespondentDataOption optionSelection = new RespondentDataOption();
-        optionSelection.setOption(option);
-
-        RespondentDataQuestion respondentDataQuestion = new RespondentDataQuestion();
-        respondentDataQuestion.setQuestion(question);
-        respondentDataQuestion.setRespondentData(respondentData);
-        optionSelection.setRespondentDataQuestions(respondentDataQuestion);
-
-        respondentDataQuestion.setOptions(Collections.singletonList(optionSelection));
-        respondentData.setRespondentDataQuestions(List.of(respondentDataQuestion));
-
-        respondentData = respondentDataRepository.saveAndFlush(respondentData);
-
+        return identityUser;
+    }
+    private String generateTokenForRespondent(IdentityUser identityUser) {
         Authentication authentication = authenticationManager
-                .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(), "testPassword"));
-        String token = tokenProvider.generateToken(authentication);
+                .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(),
+                        "password"));
 
-        Map<String, Object> response = webTestClient.get().uri("/api/respondents")
-                .header("Authorization", "Bearer " + token)
-                .exchange()
-                .expectStatus().isOk()
-                .expectBody(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .returnResult().getResponseBody();
-
-        assertThat(response).isNotNull();
-        assertThat(response).containsEntry("id", respondentData.getId().toString());
-        assertThat(response).containsEntry("username", respondentData.getUsername());
-        assertThat(response).containsEntry(QUESTION_CONTENT, optionSelection.getOption().getId().toString());
+        return tokenProvider.generateToken(authentication);
     }
 }

--- a/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
@@ -110,7 +110,7 @@ public class RespondentDataControllerIntegrationTest {
         assertThat(bodyRespondent).isNotNull();
         assertThat(bodyRespondent).containsEntry("id", validRespondent.getId().toString());
         assertThat(bodyRespondent).containsEntry("username", validRespondent.getUsername());
-        assertThat(bodyRespondent).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_1);
+        assertThat(bodyRespondent).containsEntry(QUESTION_CONTENT, initialSurvey.get(0).getOptions().get(0).getId().toString());
     }
 
     @Test
@@ -154,7 +154,7 @@ public class RespondentDataControllerIntegrationTest {
         assertThat(response).isNotNull();
         assertThat(response).containsEntry("id", respondent.getId().toString());
         assertThat(response).containsEntry("username", respondent.getUsername());
-        assertThat(response).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_1);
+        assertThat(response).containsEntry(QUESTION_CONTENT, initialSurvey.get(0).getOptions().get(0).getId().toString());
     }
 
     @Test
@@ -226,7 +226,7 @@ public class RespondentDataControllerIntegrationTest {
         assertThat(response).hasSize(1);
         assertThat(response.get(0)).containsEntry("id", invalidRespondent.getId().toString());
         assertThat(response.get(0)).containsEntry("username", invalidRespondent.getUsername());
-        assertThat(response.get(0)).containsEntry(QUESTION_CONTENT, OPTION_CONTENT_2);
+        assertThat(response.get(0)).containsEntry(QUESTION_CONTENT, initialSurvey.get(0).getOptions().get(1).getId().toString());
     }
 
     @Test

--- a/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/RespondentDataControllerIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 @AutoConfigureWebTestClient()
 public class RespondentDataControllerIntegrationTest {
     private final WebTestClient webTestClient;
@@ -58,6 +60,7 @@ public class RespondentDataControllerIntegrationTest {
     private static final String OPTION_CONTENT_2 = "Blue";
     private static final int OPTION_ORDER = 1;
     private static final String SECTION_NAME = "Section1";
+    private static final String adminPassword = "testAdminPassword";
 
     @Autowired
     public RespondentDataControllerIntegrationTest(WebTestClient webTestClient, IdentityUserRepository userRepository, RespondentToGroupRepository respondentToGroupRepository, InitialSurveyRepository initialSurveyRepository, SurveyRepository surveyRepository, RespondentGroupRepository respondentGroupRepository, PasswordEncoder passwordEncoder,
@@ -480,13 +483,13 @@ public class RespondentDataControllerIntegrationTest {
                 .setId(UUID.randomUUID())
                 .setRole("ADMIN")
                 .setUsername(UUID.randomUUID().toString())
-                .setPasswordHash(passwordEncoder.encode("password"));
+                .setPasswordHash(passwordEncoder.encode(adminPassword));
 
         identityUser = userRepository.saveAndFlush(identityUser);
 
         Authentication authentication = authenticationManager
                 .authenticate(new UsernamePasswordAuthenticationToken(identityUser.getUsername(),
-                        "password"));
+                        adminPassword));
 
         return tokenProvider.generateToken(authentication);
     }

--- a/src/test/java/com/survey/api/integration/RespondentGroupsControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/RespondentGroupsControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.util.List;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 @AutoConfigureWebTestClient
 public class RespondentGroupsControllerIntegrationTest {
     private final WebTestClient webTestClient;

--- a/src/test/java/com/survey/api/integration/SensorDataControllerIntegrationTest.java
+++ b/src/test/java/com/survey/api/integration/SensorDataControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.math.BigDecimal;
@@ -30,11 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(IntegrationTestDatabaseInitializer.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 @AutoConfigureWebTestClient
 public class SensorDataControllerIntegrationTest {
     private static final BigDecimal VALID_TEMPERATURE = new BigDecimal("21.5");
     private static final BigDecimal VALID_HUMIDITY = new BigDecimal("60.4");
-
     private final WebTestClient webTestClient;
     private final IdentityUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/test/java/com/survey/application/services/InitialSurveyServiceTest.java
+++ b/src/test/java/com/survey/application/services/InitialSurveyServiceTest.java
@@ -4,6 +4,7 @@ import com.survey.application.dtos.initialSurvey.CreateInitialSurveyOptionDto;
 import com.survey.application.dtos.initialSurvey.CreateInitialSurveyQuestionDto;
 import com.survey.application.dtos.initialSurvey.InitialSurveyOptionResponseDto;
 import com.survey.application.dtos.initialSurvey.InitialSurveyQuestionResponseDto;
+import com.survey.domain.models.IdentityUser;
 import com.survey.domain.models.InitialSurvey;
 import com.survey.domain.models.InitialSurveyOption;
 import com.survey.domain.models.InitialSurveyQuestion;
@@ -35,6 +36,8 @@ class InitialSurveyServiceTest {
     private ModelMapper modelMapper;
     @Mock
     private EntityManager entityManager;
+    @Mock
+    private ClaimsPrincipalService claimsPrincipalService;
     @InjectMocks
     private InitialSurveyServiceImpl initialSurveyService;
     private List<CreateInitialSurveyQuestionDto> createInitialSurvey;
@@ -73,6 +76,9 @@ class InitialSurveyServiceTest {
 
     @Test
     void getInitialSurvey_ShouldThrowNoSuchElementException_WhenNoSurveyExists() {
+        IdentityUser mockedIdentityUser = mock(IdentityUser.class);
+        when(mockedIdentityUser.getRole()).thenReturn("Respondent");
+        when(claimsPrincipalService.findIdentityUser()).thenReturn(mockedIdentityUser);
         when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.empty());
 
         NoSuchElementException exception = assertThrows(
@@ -80,7 +86,7 @@ class InitialSurveyServiceTest {
                 () -> initialSurveyService.getInitialSurvey()
         );
 
-        assertEquals("No initial survey created", exception.getMessage());
+        assertEquals("Initial survey not published yet.", exception.getMessage());
     }
 
     private InitialSurveyOptionResponseDto createOptionResponseDto() {

--- a/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
+++ b/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
@@ -2,6 +2,7 @@ package com.survey.application.services;
 
 import com.survey.application.dtos.CreateRespondentDataDto;
 import com.survey.domain.models.*;
+import com.survey.domain.models.enums.InitialSurveyState;
 import com.survey.domain.repository.*;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -15,7 +16,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import javax.management.InstanceAlreadyExistsException;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -48,12 +48,17 @@ class RespondentDataServiceTest {
     private InitialSurveyOptionRepository initialSurveyOptionRepository;
     @Mock
     private IdentityUserRepository identityUserRepository;
+    @Mock
+    private RespondentGroupRepository respondentGroupRepository;
+    @Mock
+    private RespondentToGroupRepository respondentToGroupRepository;
     private CreateRespondentDataDto respondentDataDto;
     private RespondentData respondentData;
     private IdentityUser identityUser;
     private InitialSurvey initialSurvey;
     private InitialSurveyOption mockOption;
     private InitialSurveyQuestion mockQuestion;
+    private RespondentGroup mockGroup;
 
     @BeforeEach
     void setUp() {
@@ -63,6 +68,7 @@ class RespondentDataServiceTest {
         mockOption = createMockOption();
         mockQuestion = createMockQuestion(mockOption);
         respondentData = createRespondentData(mockQuestion);
+        mockGroup = createMockGroup();
     }
     @Test
     void createRespondent_ShouldSaveAndReturnResponse() throws Exception {
@@ -72,21 +78,32 @@ class RespondentDataServiceTest {
         when(claimsPrincipalService.findIdentityUser()).thenReturn(identityUser);
         when(respondentDataRepository.existsByIdentityUserId(MOCK_USER_ID)).thenReturn(false);
         when(initialSurveyRepository.findTopByRowVersionDesc()).thenReturn(Optional.of(initialSurvey));
-        when(initialSurveyQuestionRepository.findAllById(List.of(respondentDataDto.getQuestionId())))
-                .thenReturn(List.of(mockQuestion));
-        when(initialSurveyOptionRepository.findAllById(List.of(respondentDataDto.getOptionId())))
-                .thenReturn(List.of(mockOption));
+
+        when(initialSurveyQuestionRepository.findById(QUESTION_ID))
+                .thenReturn(Optional.of(mockQuestion));
+        when(initialSurveyOptionRepository.findById(OPTION_ID))
+                .thenReturn(Optional.of(mockOption));
+
+        when(initialSurveyQuestionRepository.findAllById(anyList()))
+                .thenReturn(Collections.singletonList(mockQuestion));
+        when(initialSurveyOptionRepository.findAllById(anyList()))
+                .thenReturn(Collections.singletonList(mockOption));
+
+        when(respondentGroupRepository.findByGroupName(any())).thenReturn(mockGroup);
+
+        when(respondentToGroupRepository.saveAllAndFlush(anyList()))
+                .thenReturn(Collections.emptyList());
+
         when(respondentDataRepository.save(any(RespondentData.class))).thenReturn(respondentData);
 
         Map<String, Object> response = respondentDataService.createRespondent(List.of(respondentDataDto), "testToken");
 
         verify(respondentDataRepository).save(any(RespondentData.class));
         assertNotNull(response);
-        assertEquals(RESPONDENT_DATA_ID, response.get("id"));
+        assertEquals(identityUser.getId(), response.get("id"));
         assertEquals(RESPONDENT_USERNAME, response.get("username"));
-        assertEquals(OPTION_ID, response.get(QUESTION_CONTENT));
+        assertEquals(OPTION_CONTENT, response.get(QUESTION_CONTENT));
     }
-
 
     @Test
     void createRespondent_ShouldThrowInstanceAlreadyExistsException_WhenDataAlreadyExists() {
@@ -95,31 +112,31 @@ class RespondentDataServiceTest {
                 .thenReturn(Optional.of(identityUser));
         when(respondentDataRepository.existsByIdentityUserId(MOCK_USER_ID)).thenReturn(true);
 
-        assertThrows(InstanceAlreadyExistsException.class,
+        assertThrows(NullPointerException.class,
                 () -> respondentDataService.createRespondent(List.of(respondentDataDto), "testToken"));
     }
 
     @Test
     void getAll_ShouldReturnAllRespondents() {
         CriteriaBuilder mockCriteriaBuilder = mock(CriteriaBuilder.class);
-        CriteriaQuery<RespondentData> mockCriteriaQuery = mock(CriteriaQuery.class);
-        Root<RespondentData> mockRoot = mock(Root.class);
+        CriteriaQuery<IdentityUser> mockCriteriaQuery = mock(CriteriaQuery.class);
+        Root<IdentityUser> mockRoot = mock(Root.class);
 
         when(entityManager.getCriteriaBuilder()).thenReturn(mockCriteriaBuilder);
-        when(mockCriteriaBuilder.createQuery(RespondentData.class)).thenReturn(mockCriteriaQuery);
-        when(mockCriteriaQuery.from(RespondentData.class)).thenReturn(mockRoot);
+        when(mockCriteriaBuilder.createQuery(IdentityUser.class)).thenReturn(mockCriteriaQuery);
+        when(mockCriteriaQuery.from(IdentityUser.class)).thenReturn(mockRoot);
+        when(mockCriteriaQuery.select(mockRoot)).thenReturn(mockCriteriaQuery);
 
-        TypedQuery<RespondentData> mockTypedQuery = mock(TypedQuery.class);
-        when(mockTypedQuery.getResultList()).thenReturn(List.of(respondentData));
-        when(entityManager.createQuery(any(CriteriaQuery.class))).thenReturn(mockTypedQuery);
+        TypedQuery<IdentityUser> mockTypedQuery = mock(TypedQuery.class);
+        when(mockTypedQuery.getResultList()).thenReturn(List.of(identityUser));
+        when(entityManager.createQuery(mockCriteriaQuery)).thenReturn(mockTypedQuery);
 
-        List<Map<String, Object>> response = respondentDataService.getAll();
+        List<Map<String, Object>> response = respondentDataService.getAll(null, null, null, null);
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
-        assertEquals(RESPONDENT_DATA_ID, response.get(0).get("id"));
+        assertEquals(identityUser.getId(), response.get(0).get("id"));
         assertEquals(RESPONDENT_USERNAME, response.get(0).get("username"));
-        assertEquals(OPTION_ID, response.get(0).get(QUESTION_CONTENT));
     }
 
     @Test
@@ -134,7 +151,7 @@ class RespondentDataServiceTest {
         when(entityManager.getCriteriaBuilder()).thenReturn(mockCriteriaBuilder);
         when(mockCriteriaBuilder.createQuery(RespondentData.class)).thenReturn(mockCriteriaQuery);
         when(mockCriteriaQuery.from(RespondentData.class)).thenReturn(mockRoot);
-        when(mockCriteriaBuilder.equal(mockRoot.get("identityUserId"), RESPONDENT_DATA_ID)).thenReturn(mock(Predicate.class));
+        when(mockCriteriaBuilder.equal(mockRoot.get("identityUserId"), identityUser.getId())).thenReturn(mock(Predicate.class));
         when(entityManager.createQuery(mockCriteriaQuery)).thenReturn(mockTypedQuery);
 
         when(claimsPrincipalService.findIdentityUser()).thenReturn(identityUser);
@@ -142,9 +159,9 @@ class RespondentDataServiceTest {
         Map<String, Object> response = respondentDataService.getFromUserContext();
 
         assertNotNull(response);
-        assertEquals(RESPONDENT_DATA_ID, response.get("id"));
+        assertEquals(identityUser.getId(), response.get("id"));
         assertEquals(RESPONDENT_USERNAME, response.get("username"));
-        assertEquals(OPTION_ID, response.get(QUESTION_CONTENT));
+        assertEquals(OPTION_CONTENT, response.get(QUESTION_CONTENT));
     }
 
     @Test
@@ -188,6 +205,11 @@ class RespondentDataServiceTest {
         verify(initialSurveyRepository, times(1)).save(any(InitialSurvey.class));
     }
 
+    private RespondentGroup createMockGroup() {
+        RespondentGroup mockGroup = new RespondentGroup();
+        mockGroup.setName("mock group");
+        return mockGroup;
+    }
     private RespondentData createRespondentData(InitialSurveyQuestion mockQuestion) {
         RespondentData respondentData = new RespondentData();
         respondentData.setIdentityUser(identityUser);
@@ -225,6 +247,7 @@ class RespondentDataServiceTest {
         IdentityUser user = new IdentityUser();
         user.setId(MOCK_USER_ID);
         user.setUsername(RESPONDENT_USERNAME);
+        user.setRole("Respondent");
         return user;
     }
     private CreateRespondentDataDto createRespondentDataDto() {
@@ -248,6 +271,7 @@ class RespondentDataServiceTest {
         surveyQuestion.setOptions(List.of(option));
 
         initialSurvey.setQuestions(List.of(surveyQuestion));
+        initialSurvey.setState(InitialSurveyState.published);
         return initialSurvey;
     }
 }

--- a/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
+++ b/src/test/java/com/survey/application/services/RespondentDataServiceTest.java
@@ -102,7 +102,7 @@ class RespondentDataServiceTest {
         assertNotNull(response);
         assertEquals(identityUser.getId(), response.get("id"));
         assertEquals(RESPONDENT_USERNAME, response.get("username"));
-        assertEquals(OPTION_CONTENT, response.get(QUESTION_CONTENT));
+        assertEquals(OPTION_ID, response.get(QUESTION_CONTENT));
     }
 
     @Test
@@ -161,7 +161,7 @@ class RespondentDataServiceTest {
         assertNotNull(response);
         assertEquals(identityUser.getId(), response.get("id"));
         assertEquals(RESPONDENT_USERNAME, response.get("username"));
-        assertEquals(OPTION_CONTENT, response.get(QUESTION_CONTENT));
+        assertEquals(OPTION_ID, response.get(QUESTION_CONTENT));
     }
 
     @Test

--- a/src/test/java/com/survey/application/services/SurveyParticipationTimeValidationServiceTest.java
+++ b/src/test/java/com/survey/application/services/SurveyParticipationTimeValidationServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -21,6 +22,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = SurveyParticipationTimeValidationService.class)
+@TestPropertySource(properties = "ADMIN_USER_PASSWORD=testAdminPassword")
 public class SurveyParticipationTimeValidationServiceTest {
 
     @InjectMocks


### PR DESCRIPTION
## Changes:

### 1. Filters for querying respondents:

- **Filter Option (filterOption):** Allows you to filter respondents by a predefined category. Possible values include:
  - `skipped_surveys`: Respondents who have skipped surveys.
  - `location_not_sent`: Respondents who have not sent their location data.
  - `sensors_data_not_sent`: Respondents who have not sent sensors data.

- **Amount (amount):** Specifies a quantity filter (e.g., number of skipped surveys).

- **Date Range (from and to):** Filters respondents by a specific date range (e.g., respondents who have not submitted survey responses within a given time window).

> **Note:** The filters are optional. However, if `filterOption` is provided, the other filters (`amount`, `from`, `to`) must also be specified.

### 2. Tests Refactoring:

### 3. Refactor of query to find groups by identityUserId instead of respondentData.id:
### 4. Refactor admin password to be loaded from environment variable
