### PR TITLE
#138: fix image storage service

### DIFF
--- a/src/main/java/com/survey/api/controllers/UploadsController.java
+++ b/src/main/java/com/survey/api/controllers/UploadsController.java
@@ -12,13 +12,16 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/uploads")
 public class UploadsController {
     private final Path basePath = Paths.get("uploads");
+
     @GetMapping("/**")
     public ResponseEntity<Resource> getImage() throws MalformedURLException {
         String pathFromRequest = extractPathFromRequest();
@@ -38,9 +41,11 @@ public class UploadsController {
         }
     }
     private String extractPathFromRequest() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
-        return request.getRequestURI();
+        HttpServletRequest request = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes())).getRequest();
+        String requestURI = request.getRequestURI();
+        return java.net.URLDecoder.decode(requestURI, StandardCharsets.UTF_8);
     }
+
     private String getContentType(Path path) {
         String fileName = path.getFileName().toString().toLowerCase();
         if (fileName.endsWith(".png")) {

--- a/src/main/java/com/survey/api/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/survey/api/handlers/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.InvalidAttributeValueException;
@@ -121,5 +122,9 @@ public class GlobalExceptionHandler {
         }
 
         return ResponseEntity.badRequest().body(errors);
+    }
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<String> handleMaxUploadSizeExceededException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/src/main/java/com/survey/application/services/FileValidationService.java
+++ b/src/main/java/com/survey/application/services/FileValidationService.java
@@ -1,0 +1,5 @@
+package com.survey.application.services;
+
+public interface FileValidationService {
+    void validateFileType(String fileName);
+}

--- a/src/main/java/com/survey/application/services/FileValidationServiceImpl.java
+++ b/src/main/java/com/survey/application/services/FileValidationServiceImpl.java
@@ -1,0 +1,23 @@
+package com.survey.application.services;
+
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+@Service
+public class FileValidationServiceImpl implements FileValidationService {
+    private static final List<String> ALLOWED_FILE_EXTENSIONS = List.of(".jpg", ".jpeg", ".png");
+    @Override
+    public void validateFileType(String fileName) {
+        String extension = getFileExtension(fileName).toLowerCase();
+        if (!ALLOWED_FILE_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("Unsupported file type: " + extension + ". Allowed types are " + ALLOWED_FILE_EXTENSIONS);
+        }
+    }
+
+    static String getFileExtension(String fileName) {
+        return fileName != null && fileName.contains(".")
+                ? fileName.substring(fileName.lastIndexOf("."))
+                : "";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,5 @@ spring.main.web-application-type=${SPRING_MAIN_WEB_APPLICATION_TYPE:SERVLET}
 spring.main.web-environment=${SPRING_MAIN_WEB_ENVIRONMENT:true}
 spring.jpa.open-in-view=${SPRING_JPA_OPEN_IN_VIEW:false}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.SQLServerDialect
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=5MB


### PR DESCRIPTION
## Added file validation and exception handling for image uploads

- Set max image size limit to 5MB
- Implemented exception handling for file size exceedance with 400 Bad Request response
- Added validation to check for acceptable image extensions (.jpg, .jpeg, .png)
- Enhanced survey name handling to support Polish characters and normalize file paths
