### PR TITLE
Drop unique constraints to allow entries with the same date time

### DIFF
--- a/src/main/resources/db/migration/U5__revert_drop_unique_on_sensor_data_table.sql
+++ b/src/main/resources/db/migration/U5__revert_drop_unique_on_sensor_data_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sensor_data ADD CONSTRAINT UQ_sensor_data_date_time_respondent_id
+UNIQUE (date_time, respondent_id);

--- a/src/main/resources/db/migration/U6__revert_drop_unique_on_localization_data_table.sql
+++ b/src/main/resources/db/migration/U6__revert_drop_unique_on_localization_data_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE localization_data ADD CONSTRAINT UQ_localization_data_date_time_respondent_id
+UNIQUE (date_time, respondent_id);

--- a/src/main/resources/db/migration/V5__alter_table_sensor_data_drop_unique_date_time.sql
+++ b/src/main/resources/db/migration/V5__alter_table_sensor_data_drop_unique_date_time.sql
@@ -1,0 +1,12 @@
+DECLARE @ConstraintName NVARCHAR(128);
+SELECT @ConstraintName = name
+FROM sys.key_constraints
+WHERE parent_object_id = OBJECT_ID('sensor_data') AND type = 'UQ';
+
+IF @ConstraintName IS NOT NULL
+BEGIN
+    EXEC('ALTER TABLE sensor_data DROP CONSTRAINT ' + @ConstraintName);
+END
+
+
+

--- a/src/main/resources/db/migration/V6__alter_table_localization_data_drop_unique_date_time.sql
+++ b/src/main/resources/db/migration/V6__alter_table_localization_data_drop_unique_date_time.sql
@@ -1,0 +1,11 @@
+DECLARE @ConstraintName NVARCHAR(128);
+SELECT @ConstraintName = name
+FROM sys.key_constraints
+WHERE parent_object_id = OBJECT_ID('localization_data') AND type = 'UQ';
+
+IF @ConstraintName IS NOT NULL
+BEGIN
+    EXEC('ALTER TABLE localization_data DROP CONSTRAINT ' + @ConstraintName);
+END
+
+


### PR DESCRIPTION
Drop unique(respondent_id, date_time) on localization_data and sensor_data tables.