### PR TITLE
modify-results-filters

### DIFF
--- a/src/main/java/com/survey/api/controllers/SensorDataController.java
+++ b/src/main/java/com/survey/api/controllers/SensorDataController.java
@@ -78,7 +78,7 @@ public class SensorDataController {
     @Operation(
             summary = "Fetch sensor readings.",
             description = """
-                    - Allows to fetch sensor reading filtered by date and time.
+                    - Allows to fetch sensor readings filtered by date and respondentId.
                     - Date and time must be passed in UTC.
                     - **Access:**
                         - ADMIN

--- a/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
+++ b/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
@@ -114,9 +114,10 @@ public class SurveyResponsesController {
                     - `surveyId`: Filter results by a specific survey ID.
                     - `respondentId`: Filter results by a specific respondent's ID.
                     - `dateFrom` and `dateTo`: Specify a date range for the results.
+                    - `outsideResearchArea`: Specify if you want to get answers only from research area, or outside research area.
                 - **Access:**
                   - ADMIN
-                    """)
+                """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "Survey results retrieved successfully.",
@@ -132,10 +133,11 @@ public class SurveyResponsesController {
             @RequestParam(value = "surveyId", required = false) UUID surveyId,
             @RequestParam(value = "respondentId", required = false) UUID identityUserId,
             @RequestParam(value = "dateFrom", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateFrom,
-            @RequestParam(value = "dateTo", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateTo) {
+            @RequestParam(value = "dateTo", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateTo,
+            @RequestParam(value = "outsideResearchArea", required = false) Boolean outsideResearchArea) {
 
         claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
-        List<SurveyResultDto> results = surveyResponsesService.getSurveyResults(surveyId, identityUserId, dateFrom, dateTo);
+        List<SurveyResultDto> results = surveyResponsesService.getSurveyResults(surveyId, identityUserId, dateFrom, dateTo, outsideResearchArea);
         return ResponseEntity.status(HttpStatus.OK).body(results);
     }
 
@@ -146,7 +148,7 @@ public class SurveyResponsesController {
                 - Allows an administrator to fetch all survey results, localization data and sensor data for all respondents.
                 - **Access:**
                   - ADMIN
-                    """)
+                """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "Results retrieved successfully.",

--- a/src/main/java/com/survey/api/validation/SurveyParticipationValidator.java
+++ b/src/main/java/com/survey/api/validation/SurveyParticipationValidator.java
@@ -4,6 +4,7 @@ import com.survey.application.services.ClaimsPrincipalService;
 import com.survey.domain.repository.SurveyParticipationRepository;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.security.authentication.BadCredentialsException;
 
 import java.util.UUID;
 
@@ -18,9 +19,12 @@ public class SurveyParticipationValidator implements ConstraintValidator<ValidSu
 
     @Override
     public boolean isValid(UUID surveyParticipationId, ConstraintValidatorContext constraintValidatorContext) {
-        UUID respondentId = claimsPrincipalService.findIdentityUser().getId();
-
-        return surveyParticipationId == null || validateSurveyParticipationId(surveyParticipationId, respondentId);
+        try {
+            UUID respondentId = claimsPrincipalService.findIdentityUser().getId();
+            return surveyParticipationId == null || validateSurveyParticipationId(surveyParticipationId, respondentId);
+        } catch (BadCredentialsException e){
+            return false;
+        }
     }
 
     private boolean validateSurveyParticipationId(UUID surveyParticipationId, UUID respondentId){

--- a/src/main/java/com/survey/application/services/SurveyResponsesService.java
+++ b/src/main/java/com/survey/application/services/SurveyResponsesService.java
@@ -14,6 +14,6 @@ import java.util.UUID;
 public interface SurveyResponsesService {
     SurveyParticipationDto saveSurveyResponseOnline(SendOnlineSurveyResponseDto sendOnlineSurveyResponseDto) throws InvalidAttributeValueException;
     List<SurveyParticipationDto> saveSurveyResponsesOffline(List<SendOfflineSurveyResponseDto> sendOfflineSurveyResponseDtoList);
-    List<SurveyResultDto> getSurveyResults(UUID surveyId, UUID identityUserId, OffsetDateTime dateFrom, OffsetDateTime dateTo);
+    List<SurveyResultDto> getSurveyResults(UUID surveyId, UUID identityUserId, OffsetDateTime dateFrom, OffsetDateTime dateTo, Boolean outsideResearchArea);
     List<AllResultsDto> getAllSurveyResults();
 }

--- a/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
@@ -202,7 +202,7 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
 
     @Override
     @Transactional
-    public List<SurveyResultDto> getSurveyResults(UUID surveyId, UUID identityUserId, OffsetDateTime dateFrom, OffsetDateTime dateTo) {
+    public List<SurveyResultDto> getSurveyResults(UUID surveyId, UUID identityUserId, OffsetDateTime dateFrom, OffsetDateTime dateTo, Boolean outsideResearchArea) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         CriteriaQuery<SurveyParticipation> cq = cb.createQuery(SurveyParticipation.class);
 
@@ -215,9 +215,11 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
         if (surveyId != null) {
             predicates.add(cb.equal(root.get("survey").get("id"), surveyId));
         }
+
         if (identityUserId != null) {
             predicates.add(cb.equal(root.get("identityUser").get("id"), identityUserId));
         }
+
         if (dateFrom != null && dateTo != null) {
             if (dateFrom.isAfter(dateTo)){
                 throw new IllegalArgumentException("The 'from' date must be before 'to' date.");
@@ -227,6 +229,15 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
             predicates.add(cb.greaterThanOrEqualTo(root.get("date"), dateFrom));
         } else if (dateTo != null) {
             predicates.add(cb.lessThanOrEqualTo(root.get("date"), dateTo));
+        }
+
+        if (outsideResearchArea != null){
+            if (outsideResearchArea == Boolean.TRUE){
+                predicates.add(cb.equal(root.get("localizationData").get("outsideResearchArea"), Boolean.TRUE));
+            }
+            else {
+                predicates.add(cb.equal(root.get("localizationData").get("outsideResearchArea"), Boolean.FALSE));
+            }
         }
 
         cq.select(root).where(cb.and(predicates.toArray(new Predicate[0])));

--- a/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
+++ b/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
@@ -75,7 +75,7 @@ class SurveyResponsesServiceImplTest {
         when(entityManager.createQuery(mockCriteriaQuery)).thenReturn(mockTypedQuery);
         when(mockTypedQuery.getResultList()).thenReturn(List.of(surveyParticipation));
 
-        List<SurveyResultDto> results = surveyResponsesService.getSurveyResults(null, null, null, null);
+        List<SurveyResultDto> results = surveyResponsesService.getSurveyResults(null, null, null, null, null);
 
         assertFalse(results.isEmpty());
         assertEquals(SURVEY_NAME, results.get(0).getSurveyName());


### PR DESCRIPTION
# #In this pr:
- Fix 500 error while validating surveyParticipationId when sending localization data. It occurred when a request with surveyParticipationId was sent to localization data endpoint and bearer token was not present.
- Add filtering survey responses by outsideResearchArea
- Refactor localizationData filtering to use CriteriaBuilder just like survey responses filtering and sensor data filtering.