### PR TITLE
Add MongoDB response documents, statistics tab, misc backend polish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test docker image build and push
+
+on:
+  push:
+    branches:
+      - test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_ACCESS_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/geosenesm/survey-api:test

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ If you inspect `main/resources/application.properties` you can see that there ar
 - `JWT_KEY` - key for jwt tokens generation
 - `JWT_EXPIRATION` - days of jwt token lifetime
 
+Optional (defaults shown in `application.properties`):
+- `SPRING_DATA_MONGODB_URI` - MongoDB connection string. Default `mongodb://localhost:27017/survey`.
+- `SPRING_DATA_MONGODB_DATABASE` - MongoDB logical database name. Default `survey`.
+
 The best idea is to configure your IDE, so that it sets those variables always, when you run the application. 
 
 ## IntelliJ Idea instruction
@@ -20,6 +24,64 @@ To configure your IntelliJ Idea to the following:
 - On the top mane open `Run` context menu
 - Go to `Debug` -> `Edit configurations` -> `Edit environmental variables`
 - Add proper variables with values and save changes
+
+# Data stores
+
+Two data stores back this service:
+
+- **MS SQL Server (primary)** — every transactional entity (identities,
+  surveys, questions, options, participations, question answers,
+  sensor/localization data, research area, phone numbers). Managed by
+  Flyway; migrations live in `src/main/resources/db/migration/`.
+- **MongoDB (secondary, response documents)** — every submitted survey
+  response is mirrored to the `surveyResponseDocuments` collection as a
+  denormalized JSON document, written via a Spring
+  `@TransactionalEventListener(AFTER_COMMIT)`, so a Mongo failure can
+  never roll back the primary SQL write. Used by the admin
+  "Response documents" tab.
+
+Locally both containers are managed by `../scripts/dev-up.ps1` (see
+`../scripts/README.md`). For a bare-hands run:
+
+```bash
+docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Str0ng!Passw0rd" \
+  -p 1433:1433 --name geosenesm-mssql -d mcr.microsoft.com/mssql/server:2022-latest
+
+docker run -p 27017:27017 --name geosenesm-mongo -d mongo:7.0
+```
+
+# Response documents API (ADMIN-only)
+
+Endpoints exposed by `SurveyResponsesController` on top of the Mongo
+collection:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/surveyresponses/documents` | Paginated list. Filters (all optional): `surveyId`, `respondentId`, `dateFrom`, `dateTo` (ISO-8601 UTC, seconds precision). Pagination: `page` (default 0), `size` (default 20, capped 200). |
+| `GET` | `/api/surveyresponses/documents/{participationId}/download` | Single document as JSON with `Content-Disposition: attachment; filename="survey-response-<id>.json"`. |
+| `GET` | `/api/surveyresponses/documents/export` | Streams a ZIP archive of every document matching the same filters. One JSON entry per response, filename `survey-response-<participationId>.json`. |
+
+The document schema (only the fields relevant to each answer are
+persisted — null / empty properties are omitted):
+
+```json
+{
+  "participationId": "<uuid>", "surveyId": "<uuid>", "surveyName": "…",
+  "respondentId":    "<uuid>", "respondentUsername": "…",
+  "participationDate": "2026-07-12T17:27:55Z",
+  "surveyStartDate":   "2026-07-12T17:26:55Z",
+  "surveyFinishDate":  "2026-07-12T17:27:55Z",
+  "answers": [
+    { "questionId": "…", "questionContent": "How do you feel today?",
+      "questionType": "single_choice",
+      "selectedOptions": [{ "optionId": "…", "label": "Great" }] },
+    { "questionId": "…", "questionContent": "Comfort?",
+      "questionType": "linear_scale", "numericAnswer": 3 }
+  ],
+  "sensorData": { "dateTime": "…", "temperature": 21.5, "humidity": 45.0 },
+  "persistedAt": "2026-07-12T17:27:55Z"
+}
+```
 
 # Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/com/survey/api/ApiApplication.java
+++ b/src/main/java/com/survey/api/ApiApplication.java
@@ -5,10 +5,17 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"com.survey.application", "com.survey.domain", "com.survey.api"})
+@ComponentScan(basePackages = {
+        "com.survey.application",
+        "com.survey.domain",
+        "com.survey.api",
+        "com.survey.infrastructure"
+})
 @EnableJpaRepositories("com.survey.domain.repository")
+@EnableMongoRepositories("com.survey.infrastructure.mongo.repository")
 @EntityScan("com.survey.domain.models")
 public class ApiApplication {
 

--- a/src/main/java/com/survey/api/configuration/SecurityConfig.java
+++ b/src/main/java/com/survey/api/configuration/SecurityConfig.java
@@ -61,6 +61,9 @@ public class SecurityConfig {
                     r.requestMatchers(HttpMethod.GET, "/api/summaries/histogram").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/surveyresponses/results").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/surveyresponses/results/all").permitAll();
+                    r.requestMatchers(HttpMethod.GET, "/api/surveyresponses/documents").permitAll();
+                    r.requestMatchers(HttpMethod.GET, "/api/surveyresponses/documents/**").permitAll();
+                    r.requestMatchers(HttpMethod.GET, "/api/statistics/**").permitAll();
                     r.requestMatchers(HttpMethod.POST, "/api/initialsurvey").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/initialsurvey").permitAll();
                     r.requestMatchers(HttpMethod.GET, "/api/initialsurvey/state").permitAll();

--- a/src/main/java/com/survey/api/controllers/StatisticsController.java
+++ b/src/main/java/com/survey/api/controllers/StatisticsController.java
@@ -1,0 +1,78 @@
+package com.survey.api.controllers;
+
+import com.survey.api.configuration.CommonApiResponse401;
+import com.survey.api.configuration.CommonApiResponse403;
+import com.survey.api.security.Role;
+import com.survey.application.dtos.statistics.GlobalStatsDetailDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDetailDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDto;
+import com.survey.application.services.ClaimsPrincipalService;
+import com.survey.application.services.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Study-wide and per-participant aggregates for the admin
+ * "Statistics" tab. All endpoints are ADMIN-only (enforced
+ * programmatically — see {@link ClaimsPrincipalService}).
+ */
+@RestController
+@RequestMapping("/api/statistics")
+@RequiredArgsConstructor
+@Tag(name = "Statistics", description = "Study aggregates for the admin dashboard.")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+    private final ClaimsPrincipalService claimsPrincipalService;
+
+    @GetMapping("/participants")
+    @Operation(
+            summary = "List participant statistics.",
+            description = "One summary row per respondent with at least one submitted response, sorted by surveys filled desc. **Access:** ADMIN")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Participant list.")})
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<List<ParticipantStatsDto>> listParticipants() {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+        return ResponseEntity.ok(statisticsService.listParticipantStats());
+    }
+
+    @GetMapping("/participants/{respondentId}")
+    @Operation(
+            summary = "Fetch stats + daily time series for one respondent.",
+            description = "**Access:** ADMIN")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Participant detail."),
+            @ApiResponse(responseCode = "404", description = "Respondent has never submitted a response.")
+    })
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<ParticipantStatsDetailDto> getParticipantDetail(
+            @PathVariable("respondentId") UUID respondentId) {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+        return ResponseEntity.ok(statisticsService.getParticipantDetail(respondentId));
+    }
+
+    @GetMapping("/global")
+    @Operation(
+            summary = "Fetch overall study aggregates + daily time series.",
+            description = "**Access:** ADMIN")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Global stats.")})
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<GlobalStatsDetailDto> getGlobal() {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+        return ResponseEntity.ok(statisticsService.getGlobalDetail());
+    }
+}

--- a/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
+++ b/src/main/java/com/survey/api/controllers/SurveyResponsesController.java
@@ -4,13 +4,18 @@ import com.survey.api.configuration.CommonApiResponse400;
 import com.survey.api.configuration.CommonApiResponse401;
 import com.survey.api.configuration.CommonApiResponse403;
 import com.survey.api.security.Role;
+import com.survey.application.dtos.PagedResponseDto;
 import com.survey.application.dtos.SurveyResultDto;
 import com.survey.application.dtos.AllResultsDto;
 import com.survey.application.dtos.surveyDtos.SendOfflineSurveyResponseDto;
 import com.survey.application.dtos.surveyDtos.SendOnlineSurveyResponseDto;
 import com.survey.application.dtos.surveyDtos.SurveyParticipationDto;
 import com.survey.application.services.ClaimsPrincipalService;
+import com.survey.application.services.SurveyResponseDocumentService;
 import com.survey.application.services.SurveyResponsesService;
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
+import org.springframework.http.HttpHeaders;
+import java.util.NoSuchElementException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -40,11 +45,15 @@ import java.util.UUID;
 @Tag(name = "Survey responses", description = "Endpoints for sending survey responses and fetching results.")
 public class SurveyResponsesController {
     private final SurveyResponsesService surveyResponsesService;
+    private final SurveyResponseDocumentService surveyResponseDocumentService;
     private final ClaimsPrincipalService claimsPrincipalService;
 
     @Autowired
-    public SurveyResponsesController(SurveyResponsesService surveyResponsesService, ClaimsPrincipalService claimsPrincipalService){
+    public SurveyResponsesController(SurveyResponsesService surveyResponsesService,
+                                     SurveyResponseDocumentService surveyResponseDocumentService,
+                                     ClaimsPrincipalService claimsPrincipalService){
         this.surveyResponsesService = surveyResponsesService;
+        this.surveyResponseDocumentService = surveyResponseDocumentService;
         this.claimsPrincipalService = claimsPrincipalService;
     }
 
@@ -189,6 +198,102 @@ public class SurveyResponsesController {
 
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
+                .body(stream);
+    }
+
+    @GetMapping("/documents")
+    @Operation(
+            summary = "List full response documents stored in MongoDB.",
+            description = """
+                - Every survey response is mirrored to MongoDB as a denormalized document
+                  after the SQL transaction commits.
+                - Returns a paginated list of documents, newest first.
+                - **Filters (all optional):**
+                    - `surveyId`, `respondentId`
+                    - `dateFrom`, `dateTo` (participation date range, UTC)
+                - **Access:** ADMIN
+                """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Response documents retrieved successfully.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PagedResponseDto.class)
+                    )
+            )
+    })
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<PagedResponseDto<SurveyResponseDocument>> listResponseDocuments(
+            @RequestParam(value = "surveyId", required = false) UUID surveyId,
+            @RequestParam(value = "respondentId", required = false) UUID respondentId,
+            @RequestParam(value = "dateFrom", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateFrom,
+            @RequestParam(value = "dateTo", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateTo,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+        int cappedSize = Math.min(Math.max(size, 1), 200);
+        int safePage = Math.max(page, 0);
+        return ResponseEntity.ok(surveyResponseDocumentService.find(
+                surveyId, respondentId, dateFrom, dateTo, safePage, cappedSize));
+    }
+
+    @GetMapping("/documents/{participationId}/download")
+    @Operation(
+            summary = "Download a single response document as JSON.",
+            description = "Returns the raw MongoDB document with a Content-Disposition attachment header. **Access:** ADMIN")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Document retrieved successfully."),
+            @ApiResponse(responseCode = "404", description = "Document not found.")
+    })
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<SurveyResponseDocument> downloadResponseDocument(
+            @PathVariable("participationId") UUID participationId) {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+        SurveyResponseDocument document = surveyResponseDocumentService.findById(participationId)
+                .orElseThrow(() -> new NoSuchElementException("Response document not found"));
+
+        String filename = "survey-response-" + participationId + ".json";
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(document);
+    }
+
+    @GetMapping("/documents/export")
+    @Operation(
+            summary = "Export all filtered response documents as a ZIP archive.",
+            description = """
+                - Streams a ZIP archive containing one JSON entry per matching document.
+                - Filters mirror `/documents` (all optional): `surveyId`, `respondentId`,
+                  `dateFrom`, `dateTo`.
+                - **Access:** ADMIN
+                """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "ZIP archive streamed successfully.")
+    })
+    @CommonApiResponse401
+    @CommonApiResponse403
+    public ResponseEntity<StreamingResponseBody> exportResponseDocuments(
+            @RequestParam(value = "surveyId", required = false) UUID surveyId,
+            @RequestParam(value = "respondentId", required = false) UUID respondentId,
+            @RequestParam(value = "dateFrom", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateFrom,
+            @RequestParam(value = "dateTo", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'") OffsetDateTime dateTo) {
+        claimsPrincipalService.ensureRole(Role.ADMIN.getRoleName());
+
+        String filename = "survey-responses-"
+                + OffsetDateTime.now(java.time.ZoneOffset.UTC)
+                        .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss'Z'"))
+                + ".zip";
+
+        StreamingResponseBody stream = out -> surveyResponseDocumentService
+                .exportZip(surveyId, respondentId, dateFrom, dateTo, out);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"")
+                .contentType(MediaType.parseMediaType("application/zip"))
                 .body(stream);
     }
 }

--- a/src/main/java/com/survey/api/handlers/GlobalExceptionHandler.java
+++ b/src/main/java/com/survey/api/handlers/GlobalExceptionHandler.java
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Throwable.class)
-    public ResponseEntity<String> handleThrowable(RuntimeException ex) {
+    public ResponseEntity<String> handleThrowable(Throwable ex) {
         LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
         return ResponseEntity.internalServerError().body("Something went wrong: " + ex.getMessage());
     }

--- a/src/main/java/com/survey/application/dtos/PagedResponseDto.java
+++ b/src/main/java/com/survey/application/dtos/PagedResponseDto.java
@@ -1,0 +1,20 @@
+package com.survey.application.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PagedResponseDto<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/src/main/java/com/survey/application/dtos/statistics/GlobalStatsDetailDto.java
+++ b/src/main/java/com/survey/application/dtos/statistics/GlobalStatsDetailDto.java
@@ -1,0 +1,16 @@
+package com.survey.application.dtos.statistics;
+
+import java.util.List;
+
+/** Detail response combining global summary with daily series. */
+public record GlobalStatsDetailDto(
+        GlobalStatsDto stats,
+        List<TimeSeriesPointDto> participationsPerDay,
+        List<TimeSeriesPointDto> locationDataPerDay,
+        List<TimeSeriesPointDto> sensorDataPerDay,
+        /**
+         * Top participants by surveys filled, for the "filled vs available"
+         * comparison bar chart. Bounded server-side to keep payloads small.
+         */
+        List<ParticipantStatsDto> topParticipants
+) {}

--- a/src/main/java/com/survey/application/dtos/statistics/GlobalStatsDto.java
+++ b/src/main/java/com/survey/application/dtos/statistics/GlobalStatsDto.java
@@ -1,0 +1,19 @@
+package com.survey.application.dtos.statistics;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Aggregated statistics across every participant that has ever filled
+ * at least one survey. {@code firstParticipationDate} /
+ * {@code lastParticipationDate} form the overall study window. Same
+ * counting rules as {@link ParticipantStatsDto}.
+ */
+public record GlobalStatsDto(
+        OffsetDateTime firstParticipationDate,
+        OffsetDateTime lastParticipationDate,
+        long totalParticipants,
+        long surveysFilled,
+        long surveysAvailable,
+        long locationDataCount,
+        long sensorDataCount
+) {}

--- a/src/main/java/com/survey/application/dtos/statistics/ParticipantStatsDetailDto.java
+++ b/src/main/java/com/survey/application/dtos/statistics/ParticipantStatsDetailDto.java
@@ -1,0 +1,11 @@
+package com.survey.application.dtos.statistics;
+
+import java.util.List;
+
+/** Detail response combining participant summary with daily series. */
+public record ParticipantStatsDetailDto(
+        ParticipantStatsDto stats,
+        List<TimeSeriesPointDto> participationsPerDay,
+        List<TimeSeriesPointDto> locationDataPerDay,
+        List<TimeSeriesPointDto> sensorDataPerDay
+) {}

--- a/src/main/java/com/survey/application/dtos/statistics/ParticipantStatsDto.java
+++ b/src/main/java/com/survey/application/dtos/statistics/ParticipantStatsDto.java
@@ -1,0 +1,25 @@
+package com.survey.application.dtos.statistics;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * Summary statistics for a single participant over their personal study
+ * window {@code [firstParticipationDate, lastParticipationDate]}.
+ *
+ * <p>The domain rule that drives {@code surveysAvailable} is: <em>we
+ * assume a participant took part in the study between their first and
+ * last submitted survey response</em>. Any {@code SurveyParticipationTimeSlot}
+ * (non-deleted) whose {@code [start, finish]} range overlaps that
+ * window counts as "available" to the participant.</p>
+ */
+public record ParticipantStatsDto(
+        UUID respondentId,
+        String username,
+        OffsetDateTime firstParticipationDate,
+        OffsetDateTime lastParticipationDate,
+        long surveysFilled,
+        long surveysAvailable,
+        long locationDataCount,
+        long sensorDataCount
+) {}

--- a/src/main/java/com/survey/application/dtos/statistics/TimeSeriesPointDto.java
+++ b/src/main/java/com/survey/application/dtos/statistics/TimeSeriesPointDto.java
@@ -1,0 +1,6 @@
+package com.survey.application.dtos.statistics;
+
+import java.time.LocalDate;
+
+/** One (UTC-day, count) datum used to plot line charts. */
+public record TimeSeriesPointDto(LocalDate date, long count) {}

--- a/src/main/java/com/survey/application/events/SurveyResponseSubmittedEvent.java
+++ b/src/main/java/com/survey/application/events/SurveyResponseSubmittedEvent.java
@@ -1,0 +1,11 @@
+package com.survey.application.events;
+
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
+
+/**
+ * Published by {@code SurveyResponsesServiceImpl} after each survey
+ * participation is saved to SQL. Handled after commit so failures in the
+ * Mongo mirror can never roll back the primary SQL write.
+ */
+public record SurveyResponseSubmittedEvent(SurveyResponseDocument document) {
+}

--- a/src/main/java/com/survey/application/services/StatisticsService.java
+++ b/src/main/java/com/survey/application/services/StatisticsService.java
@@ -1,0 +1,24 @@
+package com.survey.application.services;
+
+import com.survey.application.dtos.statistics.GlobalStatsDetailDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDetailDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Read-only aggregates for the admin "Statistics" tab. All queries are
+ * scoped to respondents who have submitted at least one survey response.
+ */
+public interface StatisticsService {
+
+    /** Summary row per respondent, sorted by surveys filled desc. */
+    List<ParticipantStatsDto> listParticipantStats();
+
+    /** Summary + daily time series for a single respondent. */
+    ParticipantStatsDetailDto getParticipantDetail(UUID respondentId);
+
+    /** Overall study aggregates + daily series across all respondents. */
+    GlobalStatsDetailDto getGlobalDetail();
+}

--- a/src/main/java/com/survey/application/services/StatisticsServiceImpl.java
+++ b/src/main/java/com/survey/application/services/StatisticsServiceImpl.java
@@ -1,0 +1,203 @@
+package com.survey.application.services;
+
+import com.survey.application.dtos.statistics.GlobalStatsDetailDto;
+import com.survey.application.dtos.statistics.GlobalStatsDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDetailDto;
+import com.survey.application.dtos.statistics.ParticipantStatsDto;
+import com.survey.application.dtos.statistics.TimeSeriesPointDto;
+import com.survey.domain.repository.LocalizationDataRepository;
+import com.survey.domain.repository.SensorDataRepository;
+import com.survey.domain.repository.SurveyParticipationRepository;
+import com.survey.domain.repository.SurveyParticipationTimeSlotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Computes global and per-participant study aggregates.
+ *
+ * <p>Design notes:
+ * <ul>
+ *   <li>Everything is bucketed by UTC calendar day — we don't try to
+ *       auto-detect the researcher's timezone. This keeps series aligned
+ *       with the ISO-8601 timestamps we already persist.</li>
+ *   <li>"Study window" for a participant is
+ *       {@code [firstParticipationDate, lastParticipationDate]}. If they
+ *       filled only one survey both dates are equal and the window
+ *       collapses to a single instant.</li>
+ *   <li>Global "surveys available" is the <em>sum</em> of every
+ *       participant's own {@code surveysAvailable} (an "opportunity" is
+ *       always evaluated against a single participant's window). This
+ *       keeps {@code surveysFilled / surveysAvailable} a valid ratio at
+ *       both scopes and prevents time slots outside all study windows
+ *       from being counted at all.</li>
+ *   <li>Aggregation is done in Java rather than SQL {@code DATE(x)} so
+ *       we stay portable across SQL Server versions. Datasets are
+ *       expected to be at most tens of thousands of rows per study; if
+ *       that ever changes, promote the grouping to SQL.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatisticsServiceImpl implements StatisticsService {
+
+    private static final int TOP_PARTICIPANTS_LIMIT = 20;
+
+    private final SurveyParticipationRepository participationRepository;
+    private final LocalizationDataRepository localizationDataRepository;
+    private final SensorDataRepository sensorDataRepository;
+    private final SurveyParticipationTimeSlotRepository timeSlotRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ParticipantStatsDto> listParticipantStats() {
+        return participationRepository.aggregateParticipationsPerRespondent().stream()
+                .map(this::toParticipantStats)
+                .sorted(Comparator.comparingLong(ParticipantStatsDto::surveysFilled).reversed())
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ParticipantStatsDetailDto getParticipantDetail(UUID respondentId) {
+        ParticipantStatsDto stats = listParticipantStats().stream()
+                .filter(p -> p.respondentId().equals(respondentId))
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException(
+                        "No participation found for respondent " + respondentId));
+
+        List<OffsetDateTime> participationDates =
+                participationRepository.findDatesByRespondentId(respondentId);
+        List<OffsetDateTime> locationDates =
+                localizationDataRepository.findDateTimesForRespondentInWindow(
+                        respondentId,
+                        stats.firstParticipationDate(),
+                        stats.lastParticipationDate());
+        List<OffsetDateTime> sensorDates =
+                sensorDataRepository.findDateTimesForRespondentInWindow(
+                        respondentId,
+                        stats.firstParticipationDate(),
+                        stats.lastParticipationDate());
+
+        LocalDate from = toUtcDate(stats.firstParticipationDate());
+        LocalDate to = toUtcDate(stats.lastParticipationDate());
+
+        return new ParticipantStatsDetailDto(
+                stats,
+                bucketByDay(participationDates, from, to),
+                bucketByDay(locationDates, from, to),
+                bucketByDay(sensorDates, from, to)
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GlobalStatsDetailDto getGlobalDetail() {
+        List<ParticipantStatsDto> all = listParticipantStats();
+
+        if (all.isEmpty()) {
+            return new GlobalStatsDetailDto(
+                    new GlobalStatsDto(null, null, 0, 0, 0, 0, 0),
+                    List.of(), List.of(), List.of(), List.of());
+        }
+
+        OffsetDateTime firstDate = all.stream()
+                .map(ParticipantStatsDto::firstParticipationDate)
+                .min(Comparator.naturalOrder())
+                .orElseThrow();
+        OffsetDateTime lastDate = all.stream()
+                .map(ParticipantStatsDto::lastParticipationDate)
+                .max(Comparator.naturalOrder())
+                .orElseThrow();
+        long surveysFilled = all.stream().mapToLong(ParticipantStatsDto::surveysFilled).sum();
+        // Sum per-participant availabilities rather than counting distinct
+        // slots over the union window: a time slot that overlaps N
+        // participants' study windows represents N opportunities, and one
+        // that falls in a gap between participants represents zero. This
+        // keeps `surveysFilled / surveysAvailable` a valid ratio.
+        long surveysAvailable = all.stream().mapToLong(ParticipantStatsDto::surveysAvailable).sum();
+        long locationDataCount = all.stream().mapToLong(ParticipantStatsDto::locationDataCount).sum();
+        long sensorDataCount = all.stream().mapToLong(ParticipantStatsDto::sensorDataCount).sum();
+
+        List<OffsetDateTime> participationDates = participationRepository.findAllDatesOrdered();
+        List<OffsetDateTime> locationDates =
+                localizationDataRepository.findAllDateTimesInWindow(firstDate, lastDate);
+        List<OffsetDateTime> sensorDates =
+                sensorDataRepository.findAllDateTimesInWindow(firstDate, lastDate);
+
+        LocalDate from = toUtcDate(firstDate);
+        LocalDate to = toUtcDate(lastDate);
+
+        GlobalStatsDto stats = new GlobalStatsDto(
+                firstDate, lastDate,
+                all.size(), surveysFilled, surveysAvailable,
+                locationDataCount, sensorDataCount);
+
+        List<ParticipantStatsDto> topParticipants = all.stream()
+                .limit(TOP_PARTICIPANTS_LIMIT)
+                .toList();
+
+        return new GlobalStatsDetailDto(
+                stats,
+                bucketByDay(participationDates, from, to),
+                bucketByDay(locationDates, from, to),
+                bucketByDay(sensorDates, from, to),
+                topParticipants
+        );
+    }
+
+    private ParticipantStatsDto toParticipantStats(Object[] row) {
+        UUID respondentId = (UUID) row[0];
+        String username = (String) row[1];
+        OffsetDateTime firstDate = (OffsetDateTime) row[2];
+        OffsetDateTime lastDate = (OffsetDateTime) row[3];
+        long surveysFilled = ((Number) row[4]).longValue();
+        long surveysAvailable = timeSlotRepository.countOverlappingWindow(firstDate, lastDate);
+        long locationDataCount = localizationDataRepository.countByIdentityUserId(respondentId);
+        long sensorDataCount = sensorDataRepository.countByRespondentId(respondentId);
+        return new ParticipantStatsDto(
+                respondentId, username,
+                firstDate, lastDate,
+                surveysFilled, surveysAvailable,
+                locationDataCount, sensorDataCount);
+    }
+
+    private static LocalDate toUtcDate(OffsetDateTime moment) {
+        return moment.withOffsetSameInstant(ZoneOffset.UTC).toLocalDate();
+    }
+
+    /**
+     * Groups {@code timestamps} by UTC day and fills every calendar day
+     * from {@code from} to {@code to} inclusive (with 0 for empty days),
+     * so echarts renders a continuous x-axis instead of a jagged one.
+     */
+    private static List<TimeSeriesPointDto> bucketByDay(
+            List<OffsetDateTime> timestamps, LocalDate from, LocalDate to) {
+
+        Map<LocalDate, Long> counts = timestamps.stream()
+                .collect(Collectors.groupingBy(
+                        StatisticsServiceImpl::toUtcDate,
+                        TreeMap::new,
+                        Collectors.counting()));
+
+        List<TimeSeriesPointDto> series = new ArrayList<>();
+        for (LocalDate day = from; !day.isAfter(to); day = day.plusDays(1)) {
+            series.add(new TimeSeriesPointDto(day, counts.getOrDefault(day, 0L)));
+        }
+        return series;
+    }
+}

--- a/src/main/java/com/survey/application/services/SurveyResponseDocumentService.java
+++ b/src/main/java/com/survey/application/services/SurveyResponseDocumentService.java
@@ -1,0 +1,36 @@
+package com.survey.application.services;
+
+import com.survey.application.dtos.PagedResponseDto;
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
+
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SurveyResponseDocumentService {
+
+    PagedResponseDto<SurveyResponseDocument> find(
+            UUID surveyId,
+            UUID respondentId,
+            OffsetDateTime dateFrom,
+            OffsetDateTime dateTo,
+            int page,
+            int size
+    );
+
+    Optional<SurveyResponseDocument> findById(UUID participationId);
+
+    /**
+     * Streams every document matching the filters as a ZIP archive to
+     * {@code out}. Each entry is a pretty-printed JSON document named
+     * {@code survey-response-<participationId>.json}.
+     */
+    void exportZip(
+            UUID surveyId,
+            UUID respondentId,
+            OffsetDateTime dateFrom,
+            OffsetDateTime dateTo,
+            OutputStream out
+    ) throws java.io.IOException;
+}

--- a/src/main/java/com/survey/application/services/SurveyResponseDocumentServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveyResponseDocumentServiceImpl.java
@@ -1,0 +1,138 @@
+package com.survey.application.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.survey.application.dtos.PagedResponseDto;
+import com.survey.application.events.SurveyResponseSubmittedEvent;
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
+import com.survey.infrastructure.mongo.repository.SurveyResponseDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SurveyResponseDocumentServiceImpl implements SurveyResponseDocumentService {
+
+    private static final String PARTICIPATION_DATE_FIELD = "participationDate";
+
+    private final SurveyResponseDocumentRepository repository;
+    private final MongoTemplate mongoTemplate;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onSurveyResponseSubmitted(SurveyResponseSubmittedEvent event) {
+        SurveyResponseDocument document = event.document();
+        try {
+            repository.save(document);
+        } catch (RuntimeException ex) {
+            log.warn("Failed to mirror survey response {} to MongoDB: {}",
+                    document.getParticipationId(), ex.getMessage());
+        }
+    }
+
+    @Override
+    public PagedResponseDto<SurveyResponseDocument> find(
+            UUID surveyId,
+            UUID respondentId,
+            OffsetDateTime dateFrom,
+            OffsetDateTime dateTo,
+            int page,
+            int size
+    ) {
+        Query query = buildFilterQuery(surveyId, respondentId, dateFrom, dateTo);
+        long total = mongoTemplate.count(query, SurveyResponseDocument.class);
+
+        PageRequest pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, PARTICIPATION_DATE_FIELD));
+        query.with(pageable);
+
+        List<SurveyResponseDocument> content = mongoTemplate.find(query, SurveyResponseDocument.class);
+
+        PagedResponseDto<SurveyResponseDocument> result = new PagedResponseDto<>();
+        result.setContent(content);
+        result.setPage(page);
+        result.setSize(size);
+        result.setTotalElements(total);
+        result.setTotalPages(size == 0 ? 0 : (int) Math.ceil((double) total / size));
+        return result;
+    }
+
+    @Override
+    public Optional<SurveyResponseDocument> findById(UUID participationId) {
+        return repository.findById(participationId);
+    }
+
+    @Override
+    public void exportZip(
+            UUID surveyId,
+            UUID respondentId,
+            OffsetDateTime dateFrom,
+            OffsetDateTime dateTo,
+            OutputStream out
+    ) throws IOException {
+        Query query = buildFilterQuery(surveyId, respondentId, dateFrom, dateTo)
+                .with(Sort.by(Sort.Direction.DESC, PARTICIPATION_DATE_FIELD));
+
+        try (ZipOutputStream zip = new ZipOutputStream(out);
+             Stream<SurveyResponseDocument> cursor =
+                     mongoTemplate.stream(query, SurveyResponseDocument.class)) {
+
+            cursor.forEach(doc -> writeZipEntry(zip, doc));
+        }
+    }
+
+    private void writeZipEntry(ZipOutputStream zip, SurveyResponseDocument doc) {
+        try {
+            byte[] json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(doc);
+            zip.putNextEntry(new ZipEntry("survey-response-" + doc.getParticipationId() + ".json"));
+            zip.write(json);
+            zip.closeEntry();
+        } catch (IOException ex) {
+            throw new java.io.UncheckedIOException(ex);
+        }
+    }
+
+    private Query buildFilterQuery(
+            UUID surveyId,
+            UUID respondentId,
+            OffsetDateTime dateFrom,
+            OffsetDateTime dateTo
+    ) {
+        Query query = new Query();
+        if (surveyId != null) {
+            query.addCriteria(Criteria.where("surveyId").is(surveyId));
+        }
+        if (respondentId != null) {
+            query.addCriteria(Criteria.where("respondentId").is(respondentId));
+        }
+        if (dateFrom != null || dateTo != null) {
+            Criteria dateCriteria = Criteria.where(PARTICIPATION_DATE_FIELD);
+            if (dateFrom != null) {
+                dateCriteria = dateCriteria.gte(dateFrom);
+            }
+            if (dateTo != null) {
+                dateCriteria = dateCriteria.lte(dateTo);
+            }
+            query.addCriteria(dateCriteria);
+        }
+        return query;
+    }
+}

--- a/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
+++ b/src/main/java/com/survey/application/services/SurveyResponsesServiceImpl.java
@@ -5,18 +5,22 @@ import com.survey.api.security.Role;
 import com.survey.api.validation.SendSurveyResponseDtoValidator;
 import com.survey.application.dtos.*;
 import com.survey.application.dtos.surveyDtos.*;
+import com.survey.application.events.SurveyResponseSubmittedEvent;
 import com.survey.domain.models.*;
 import com.survey.domain.models.enums.QuestionType;
 import com.survey.domain.repository.*;
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
 import jakarta.persistence.EntityManager;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.annotation.RequestScope;
 
 import java.io.OutputStream;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,6 +41,7 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
     private final SensorDataRepository sensorDataRepository;
     private final IdentityUserRepository identityUserRepository;
     private final LocalizationDataRepository localizationDataRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     @Autowired
@@ -53,7 +58,8 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
             SurveyParticipationTimeValidationService surveyParticipationTimeValidationService,
             SensorDataRepository sensorDataRepository,
             IdentityUserRepository identityUserRepository,
-            LocalizationDataRepository localizationDataRepository) {
+            LocalizationDataRepository localizationDataRepository,
+            ApplicationEventPublisher eventPublisher) {
         this.surveyParticipationRepository = surveyParticipationRepository;
         this.surveyRepository = surveyRepository;
         this.optionRepository = optionRepository;
@@ -67,6 +73,7 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
         this.sensorDataRepository = sensorDataRepository;
         this.identityUserRepository = identityUserRepository;
         this.localizationDataRepository = localizationDataRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     Survey findSurveyById(UUID surveyId) {
@@ -187,7 +194,9 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
         SurveyParticipation finalSurveyParticipation = mapQuestionAnswers(sendOnlineSurveyResponseDto, surveyParticipation, survey);
         surveyParticipationRepository.save(finalSurveyParticipation);
         saveSensorData(sendOnlineSurveyResponseDto, finalSurveyParticipation, identityUser);
-        return mapToDto(finalSurveyParticipation, sendOnlineSurveyResponseDto, identityUser);
+        SurveyParticipationDto dto = mapToDto(finalSurveyParticipation, sendOnlineSurveyResponseDto, identityUser);
+        publishResponseSubmittedEvent(finalSurveyParticipation, identityUser, survey, sendOnlineSurveyResponseDto);
+        return dto;
     }
 
     @Override
@@ -205,10 +214,89 @@ public class SurveyResponsesServiceImpl implements SurveyResponsesService {
                     SurveyParticipation finalParticipation = mapQuestionAnswers(dto, participation, survey);
                     surveyParticipationRepository.save(finalParticipation);
                     saveSensorData(dto, finalParticipation, identityUser);
-                    return mapToDto(finalParticipation, dto, identityUser);
+                    SurveyParticipationDto mapped = mapToDto(finalParticipation, dto, identityUser);
+                    publishResponseSubmittedEvent(finalParticipation, identityUser, survey, dto);
+                    return mapped;
                 })
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    private void publishResponseSubmittedEvent(
+            SurveyParticipation participation,
+            IdentityUser identityUser,
+            Survey survey,
+            SendSurveyResponseDto submittedDto
+    ) {
+        SurveyResponseDocument document = buildResponseDocument(participation, identityUser, survey, submittedDto);
+        eventPublisher.publishEvent(new SurveyResponseSubmittedEvent(document));
+    }
+
+    private SurveyResponseDocument buildResponseDocument(
+            SurveyParticipation participation,
+            IdentityUser identityUser,
+            Survey survey,
+            SendSurveyResponseDto submittedDto
+    ) {
+        List<SurveyResponseDocument.Answer> answers = participation.getQuestionAnswers() == null
+                ? List.of()
+                : participation.getQuestionAnswers().stream()
+                        .map(this::toDocumentAnswer)
+                        .toList();
+
+        SurveyResponseDocument.SensorReading sensorReading = null;
+        if (submittedDto.getSensorData() != null) {
+            SensorDataDto sensor = submittedDto.getSensorData();
+            sensorReading = SurveyResponseDocument.SensorReading.builder()
+                    .dateTime(sensor.getDateTime())
+                    .temperature(sensor.getTemperature())
+                    .humidity(sensor.getHumidity())
+                    .build();
+        }
+
+        return SurveyResponseDocument.builder()
+                .participationId(participation.getId())
+                .surveyId(survey.getId())
+                .surveyName(survey.getName())
+                .respondentId(identityUser.getId())
+                .respondentUsername(identityUser.getUsername())
+                .participationDate(participation.getDate())
+                .surveyStartDate(submittedDto.getStartDate())
+                .surveyFinishDate(submittedDto.getFinishDate())
+                .answers(answers)
+                .sensorData(sensorReading)
+                .persistedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+    }
+
+    private SurveyResponseDocument.Answer toDocumentAnswer(QuestionAnswer questionAnswer) {
+        Question question = questionAnswer.getQuestion();
+        // Leave a field null when the question type doesn't use it: the doc
+        // marks these @Field(write = NON_NULL) so nulls are omitted from
+        // both the Mongo document and the JSON output.
+        List<SurveyResponseDocument.SelectedOption> selectedOptions = null;
+        if (questionAnswer.getOptionSelections() != null && !questionAnswer.getOptionSelections().isEmpty()) {
+            selectedOptions = questionAnswer.getOptionSelections().stream()
+                    .map(sel -> SurveyResponseDocument.SelectedOption.builder()
+                            .optionId(sel.getOption().getId())
+                            .label(sel.getOption().getLabel())
+                            .build())
+                    .toList();
+        }
+        String textAnswerContent = questionAnswer.getTextAnswer() != null
+                ? questionAnswer.getTextAnswer().getTextAnswerContent()
+                : null;
+        return SurveyResponseDocument.Answer.builder()
+                .questionId(question.getId())
+                .questionContent(question.getContent())
+                .questionType(question.getQuestionType() != null
+                        ? question.getQuestionType().name()
+                        : null)
+                .selectedOptions(selectedOptions)
+                .numericAnswer(questionAnswer.getNumericAnswer())
+                .yesNoAnswer(questionAnswer.getYesNoAnswer())
+                .textAnswer(textAnswerContent)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/survey/domain/repository/LocalizationDataRepository.java
+++ b/src/main/java/com/survey/domain/repository/LocalizationDataRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,4 +27,16 @@ public interface LocalizationDataRepository extends JpaRepository<LocalizationDa
             "LEFT JOIN FETCH ld.surveyParticipation " +
             "WHERE ld.identityUser.id IN :identityUserIds")
     List<LocalizationData> findAllByIdentityUserIdsWithFetch(List<UUID> identityUserIds);
+
+    long countByIdentityUserId(UUID identityUserId);
+
+    @Query("SELECT ld.dateTime FROM LocalizationData ld " +
+            "WHERE ld.identityUser.id = :respondentId " +
+            "AND ld.dateTime BETWEEN :from AND :to")
+    List<OffsetDateTime> findDateTimesForRespondentInWindow(
+            UUID respondentId, OffsetDateTime from, OffsetDateTime to);
+
+    @Query("SELECT ld.dateTime FROM LocalizationData ld " +
+            "WHERE ld.dateTime BETWEEN :from AND :to")
+    List<OffsetDateTime> findAllDateTimesInWindow(OffsetDateTime from, OffsetDateTime to);
 }

--- a/src/main/java/com/survey/domain/repository/SensorDataRepository.java
+++ b/src/main/java/com/survey/domain/repository/SensorDataRepository.java
@@ -26,4 +26,16 @@ public interface SensorDataRepository extends JpaRepository<SensorData, UUID> {
             "LEFT JOIN FETCH sd.surveyParticipation " +
             "WHERE sd.respondent.id IN :respondentIds")
     List<SensorData> findAllByRespondentIdsWithFetch(List<UUID> respondentIds);
+
+    long countByRespondentId(UUID respondentId);
+
+    @Query("SELECT sd.dateTime FROM SensorData sd " +
+            "WHERE sd.respondent.id = :respondentId " +
+            "AND sd.dateTime BETWEEN :from AND :to")
+    List<OffsetDateTime> findDateTimesForRespondentInWindow(
+            UUID respondentId, OffsetDateTime from, OffsetDateTime to);
+
+    @Query("SELECT sd.dateTime FROM SensorData sd " +
+            "WHERE sd.dateTime BETWEEN :from AND :to")
+    List<OffsetDateTime> findAllDateTimesInWindow(OffsetDateTime from, OffsetDateTime to);
 }

--- a/src/main/java/com/survey/domain/repository/SurveyParticipationRepository.java
+++ b/src/main/java/com/survey/domain/repository/SurveyParticipationRepository.java
@@ -31,4 +31,23 @@ public interface SurveyParticipationRepository extends JpaRepository<SurveyParti
             "LEFT JOIN FETCH sp.questionAnswers " +
             "WHERE sp.identityUser.id IN :identityUserIds")
     List<SurveyParticipation> findAllByIdentityUserIdsWithFetch(List<UUID> identityUserIds);
+
+    /**
+     * One row per respondent that has at least one participation:
+     * {@code [respondentId, username, minDate, maxDate, count]}. Used by
+     * the statistics service.
+     */
+    @Query("SELECT sp.identityUser.id, sp.identityUser.username, " +
+            "MIN(sp.date), MAX(sp.date), COUNT(sp) " +
+            "FROM SurveyParticipation sp " +
+            "GROUP BY sp.identityUser.id, sp.identityUser.username")
+    List<Object[]> aggregateParticipationsPerRespondent();
+
+    @Query("SELECT sp.date FROM SurveyParticipation sp " +
+            "WHERE sp.identityUser.id = :respondentId " +
+            "ORDER BY sp.date")
+    List<OffsetDateTime> findDatesByRespondentId(UUID respondentId);
+
+    @Query("SELECT sp.date FROM SurveyParticipation sp ORDER BY sp.date")
+    List<OffsetDateTime> findAllDatesOrdered();
 }

--- a/src/main/java/com/survey/domain/repository/SurveyParticipationTimeSlotRepository.java
+++ b/src/main/java/com/survey/domain/repository/SurveyParticipationTimeSlotRepository.java
@@ -2,6 +2,7 @@ package com.survey.domain.repository;
 
 import com.survey.domain.models.SurveyParticipationTimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -11,4 +12,16 @@ import java.util.UUID;
 public interface SurveyParticipationTimeSlotRepository extends JpaRepository<SurveyParticipationTimeSlot, UUID> {
     List<SurveyParticipationTimeSlot> findByFinishBetween(OffsetDateTime startOfDay, OffsetDateTime endOfDay);
     long countByIdIn(List<UUID> ids);
+
+    /**
+     * Count of non-deleted time slots whose {@code [start, finish]} range
+     * overlaps the given window. Overlap = {@code start <= windowEnd AND
+     * finish >= windowStart}. Represents "how many survey response
+     * opportunities the participant had during their study window".
+     */
+    @Query("SELECT COUNT(ts) FROM SurveyParticipationTimeSlot ts " +
+            "WHERE ts.isDeleted = false " +
+            "AND ts.start <= :windowEnd " +
+            "AND ts.finish >= :windowStart")
+    long countOverlappingWindow(OffsetDateTime windowStart, OffsetDateTime windowEnd);
 }

--- a/src/main/java/com/survey/infrastructure/mongo/config/MongoConfig.java
+++ b/src/main/java/com/survey/infrastructure/mongo/config/MongoConfig.java
@@ -1,0 +1,49 @@
+package com.survey.infrastructure.mongo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Persists {@link OffsetDateTime} as ISO-8601 strings so the UTC offset is
+ * preserved. Spring Data Mongo's built-in JSR-310 converter maps to
+ * {@code java.util.Date}, which silently drops the offset.
+ */
+@Configuration
+public class MongoConfig {
+
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        return new MongoCustomConversions(List.of(
+                new OffsetDateTimeToStringConverter(),
+                new StringToOffsetDateTimeConverter()
+        ));
+    }
+
+    @WritingConverter
+    static class OffsetDateTimeToStringConverter implements Converter<OffsetDateTime, String> {
+        @Override
+        public String convert(OffsetDateTime source) {
+            // Normalize to UTC so ISO-8601 strings sort/compare correctly in
+            // Mongo range queries regardless of the caller's timezone.
+            return source.withOffsetSameInstant(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+    }
+
+    @ReadingConverter
+    static class StringToOffsetDateTimeConverter implements Converter<String, OffsetDateTime> {
+        @Override
+        public OffsetDateTime convert(String source) {
+            return OffsetDateTime.parse(source, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+    }
+}

--- a/src/main/java/com/survey/infrastructure/mongo/documents/SurveyResponseDocument.java
+++ b/src/main/java/com/survey/infrastructure/mongo/documents/SurveyResponseDocument.java
@@ -1,0 +1,107 @@
+package com.survey.infrastructure.mongo.documents;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Denormalized snapshot of a single survey response. Written after the SQL
+ * transaction commits (see {@code SurveyResponseSubmittedEvent}) and read back
+ * by the admin "Response Documents" view. The {@code _id} is the SQL
+ * participation UUID, which keeps SQL and Mongo aligned without an extra key.
+ *
+ * Null / empty properties are omitted from both the Mongo document
+ * ({@code @Field(write = NON_NULL)}) and the JSON output
+ * ({@code @JsonInclude}). This keeps each answer to only the fields that
+ * actually carry a value for its question type.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Document(collection = "surveyResponseDocuments")
+public class SurveyResponseDocument {
+
+    @Id
+    private UUID participationId;
+
+    @Indexed
+    private UUID surveyId;
+    private String surveyName;
+
+    @Indexed
+    private UUID respondentId;
+    private String respondentUsername;
+
+    @Indexed
+    private OffsetDateTime participationDate;
+    private OffsetDateTime surveyStartDate;
+    private OffsetDateTime surveyFinishDate;
+
+    private List<Answer> answers;
+
+    @Field(write = Field.Write.NON_NULL)
+    private SensorReading sensorData;
+
+    private OffsetDateTime persistedAt;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Answer {
+        private UUID questionId;
+        private String questionContent;
+        private String questionType;
+
+        @Field(write = Field.Write.NON_NULL)
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private List<SelectedOption> selectedOptions;
+
+        @Field(write = Field.Write.NON_NULL)
+        private Integer numericAnswer;
+
+        @Field(write = Field.Write.NON_NULL)
+        private Boolean yesNoAnswer;
+
+        @Field(write = Field.Write.NON_NULL)
+        private String textAnswer;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SelectedOption {
+        private UUID optionId;
+        private String label;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SensorReading {
+        private OffsetDateTime dateTime;
+        private BigDecimal temperature;
+        private BigDecimal humidity;
+    }
+}

--- a/src/main/java/com/survey/infrastructure/mongo/repository/SurveyResponseDocumentRepository.java
+++ b/src/main/java/com/survey/infrastructure/mongo/repository/SurveyResponseDocumentRepository.java
@@ -1,0 +1,10 @@
+package com.survey.infrastructure.mongo.repository;
+
+import com.survey.infrastructure.mongo.documents.SurveyResponseDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.UUID;
+
+public interface SurveyResponseDocumentRepository
+        extends MongoRepository<SurveyResponseDocument, UUID> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,10 @@ spring.datasource.username=${SPRING_DATASOURCE_USER}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER:com.microsoft.sqlserver.jdbc.SQLServerDriver}
 
+spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI:mongodb://localhost:27017/survey}
+spring.data.mongodb.database=${SPRING_DATA_MONGODB_DATABASE:survey}
+spring.data.mongodb.auto-index-creation=true
+
 spring.flyway.baseline-on-migrate=${SPRING_FLYWAY_BASELINE_ON_MIGRATE:true}
 spring.flyway.enabled=${SPRING_FLYWAY_ENABLED:true}
 spring.flyway.password=${SPRING_FLYWAY_PASSWORD}

--- a/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
+++ b/src/test/java/com/survey/application/services/SurveyResponsesServiceImplTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.modelmapper.ModelMapper;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -72,6 +73,9 @@ class SurveyResponsesServiceImplTest {
     @Mock
     private LocalizationDataRepository localizationDataRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private SurveyResponsesServiceImpl surveyResponsesService;
 
     private Survey survey;
@@ -97,7 +101,8 @@ class SurveyResponsesServiceImplTest {
                 surveyParticipationTimeValidationService,
                 sensorDataRepository,
                 identityUserRepository,
-                localizationDataRepository
+                localizationDataRepository,
+                eventPublisher
         );
 
         survey = createSurvey();


### PR DESCRIPTION
- Persist every survey response as a denormalized document in MongoDB via a @TransactionalEventListener(AFTER_COMMIT); null answer fields are omitted from both storage and JSON output.
- Expose ADMIN endpoints under /api/surveyresponses/documents (paginated list, single JSON download, bulk ZIP export streamed via StreamingResponseBody + Mongo cursor stream).
- Add /api/statistics endpoints (list participants, per-participant detail, global aggregates with daily time series) for the new admin Statistics tab. Global surveysAvailable is summed per participant to keep the filled/available ratio meaningful.
- Wire spring-boot-starter-data-mongodb, custom OffsetDateTime converters (UTC normalization), and @EnableMongoRepositories in ApiApplication.
- Add JPA repository queries: aggregate participations per respondent, count location/sensor per user, count time slots overlapping a window, per-user date lists for time series.
- README documents the Mongo layer and the new response-documents / statistics endpoints; application.properties adds optional SPRING_DATA_MONGODB_URI / SPRING_DATA_MONGODB_DATABASE.